### PR TITLE
Align layout rendering with CSS standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxpdf",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "mcpName": "io.github.earonesty/boxpdf",
   "description": "Tiny box-layout DSL over pdf-lib. Flexbox-lite for server-side PDF generation in any JS runtime (Node, Cloudflare Workers, Deno, browsers).",
   "keywords": [

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -1,5 +1,5 @@
 import { edges, type Node, type Size } from "./types.js";
-import { ellipsize, fontLineHeight, fontLineMetrics, measureText, wrapText } from "./text.js";
+import { ellipsize, fontLineHeight, fontLineMetrics, measureTextSpaced, wrapText } from "./text.js";
 import {
   layoutParagraph,
   measureParagraphHeight,
@@ -137,12 +137,13 @@ export function measureContent(node: Node, parentWidth: number): Size {
   switch (node.kind) {
     case "text": {
       const { props } = node;
-      const intrinsicWidth = measureText(props.font, props.size, node.text);
+      const letterSpacing = props.letterSpacing ?? 0;
+      const intrinsicWidth = measureTextSpaced(props.font, props.size, node.text, letterSpacing);
       const slotWidth = props.width ?? intrinsicWidth;
       const wrapWidth = props.width ?? parentWidth;
       const lineHeight = props.lineHeight ?? fontLineHeight(props.font, props.size);
       const lines = props.width
-        ? clampLines(wrapText(props.font, props.size, node.text, wrapWidth, { wrap: props.wrap }), props.maxLines)
+        ? clampLines(wrapText(props.font, props.size, node.text, wrapWidth, { wrap: props.wrap, letterSpacing }), props.maxLines)
         : node.text.split(/\r?\n/);
       const usedLines = props.maxLines ? Math.min(lines.length, props.maxLines) : lines.length;
       return { width: slotWidth, height: lineHeight * Math.max(1, usedLines) };
@@ -168,7 +169,8 @@ export function measureContent(node: Node, parentWidth: number): Size {
       const fixedWidth = node.style.width;
       const innerWidth = (fixedWidth ?? parentWidth) - inset.left - inset.right;
       const fixedHeight = node.style.height;
-      const availableHeight = fixedHeight === undefined ? Infinity : fixedHeight - inset.top - inset.bottom;
+      const constrainedHeight = fixedHeight ?? node.style.maxHeight;
+      const availableHeight = constrainedHeight === undefined ? Infinity : constrainedHeight - inset.top - inset.bottom;
       const children = stretchCrossAxisChildren(
         node.children.filter((child) => !isAbsoluteBox(child)),
         "vertical",
@@ -179,9 +181,12 @@ export function measureContent(node: Node, parentWidth: number): Size {
       const totalGap = node.gap * Math.max(0, layout.children.length - 1);
       const totalHeight = layout.sizes.reduce((s, sz) => s + sz.height, 0) + totalGap;
       const maxChildWidth = layout.sizes.reduce((m, s) => (s.width > m ? s.width : m), 0);
+      let height = fixedHeight ?? totalHeight + inset.top + inset.bottom;
+      if (node.style.maxHeight !== undefined) height = Math.min(height, node.style.maxHeight);
+      if (node.style.minHeight !== undefined) height = Math.max(height, node.style.minHeight);
       return {
         width: fixedWidth ?? maxChildWidth + inset.left + inset.right,
-        height: fixedHeight ?? totalHeight + inset.top + inset.bottom
+        height
       };
     }
     case "link":
@@ -192,6 +197,40 @@ export function measureContent(node: Node, parentWidth: number): Size {
       const inset = edges(node.style.padding);
       const fixedWidth = node.style.width;
       const innerWidth = (fixedWidth ?? parentWidth) - inset.left - inset.right;
+
+      if (node.wrap) {
+        // Greedy bin-packing into rows
+        const flowChildren = node.children.filter((child) => !isAbsoluteBox(child));
+        const childSizes = flowChildren.map((child) => measure(child, innerWidth));
+        const rows: number[][] = [];
+        let rowIndices: number[] = [];
+        let rowWidth = 0;
+        for (let i = 0; i < flowChildren.length; i++) {
+          const w = childSizes[i]!.width;
+          const addGap = rowIndices.length > 0 ? node.gap : 0;
+          if (rowIndices.length > 0 && rowWidth + addGap + w > innerWidth) {
+            rows.push(rowIndices);
+            rowIndices = [i];
+            rowWidth = w;
+          } else {
+            rowIndices.push(i);
+            rowWidth += addGap + w;
+          }
+        }
+        if (rowIndices.length > 0) rows.push(rowIndices);
+        const rowHeights = rows.map((indices) =>
+          indices.reduce((m, i) => Math.max(m, childSizes[i]!.height), 0)
+        );
+        const totalRowHeight = rowHeights.reduce((s, h) => s + h, 0) + node.gap * Math.max(0, rows.length - 1);
+        let height = node.style.height ?? totalRowHeight + inset.top + inset.bottom;
+        if (node.style.maxHeight !== undefined) height = Math.min(height, node.style.maxHeight);
+        if (node.style.minHeight !== undefined) height = Math.max(height, node.style.minHeight);
+        return {
+          width: fixedWidth ?? innerWidth + inset.left + inset.right,
+          height
+        };
+      }
+
       let children = node.children.filter((child) => !isAbsoluteBox(child));
       let layout = resolveMainAxis(children, "horizontal", innerWidth, innerWidth, node.gap);
       if (node.align === "stretch") {
@@ -206,9 +245,12 @@ export function measureContent(node: Node, parentWidth: number): Size {
         node.align === "baseline"
           ? measureBaselineStackHeight(layout.children, layout.sizes, innerWidth)
           : layout.sizes.reduce((m, s) => (s.height > m ? s.height : m), 0);
+      let height = node.style.height ?? maxChildHeight + inset.top + inset.bottom;
+      if (node.style.maxHeight !== undefined) height = Math.min(height, node.style.maxHeight);
+      if (node.style.minHeight !== undefined) height = Math.max(height, node.style.minHeight);
       return {
         width: fixedWidth ?? totalWidth + inset.left + inset.right,
-        height: node.style.height ?? maxChildHeight + inset.top + inset.bottom
+        height
       };
     }
   }
@@ -221,7 +263,32 @@ export function stretchCrossAxisChildren(
   align: "start" | "center" | "end" | "stretch" | "baseline"
 ): Node[] {
   if (align !== "stretch" || !Number.isFinite(availableCross)) return children;
-  return children.map((child) => applyCrossAxisStretch(child, axis, availableCross));
+  return children.map((child) => {
+    // If the child has alignSelf set to something other than stretch, skip stretching it
+    const selfAlign = nodeAlignSelf(child);
+    if (selfAlign !== undefined && selfAlign !== "stretch") return child;
+    return applyCrossAxisStretch(child, axis, availableCross);
+  });
+}
+
+export function nodeAlignSelf(node: Node): import("./types.js").CrossAxis | undefined {
+  switch (node.kind) {
+    case "vstack":
+    case "hstack":
+      return node.style.alignSelf;
+    case "text":
+      return node.props.alignSelf;
+    case "paragraph":
+      return node.props.alignSelf;
+    case "image":
+    case "imageBox":
+    case "spacer":
+    case "hline":
+    case "vline":
+    case "link":
+    case "svgPath":
+      return node.alignSelf;
+  }
 }
 
 function measureBaselineStackHeight(children: Node[], sizes: Size[], parentWidth: number): number {
@@ -547,7 +614,7 @@ function minTextWidth(node: Extract<Node, { kind: "text" }>): number {
   if (words.length === 0) return 0;
   let max = 0;
   for (const word of words) {
-    const w = measureText(props.font, props.size, word);
+    const w = measureTextSpaced(props.font, props.size, word, props.letterSpacing ?? 0);
     if (w > max) max = w;
   }
   return max;
@@ -660,16 +727,16 @@ export function layoutText(
   const { props, text } = node;
   if (!props.width) {
     if (props.maxLines && props.maxLines >= 1) {
-      return [ellipsize(props.font, props.size, text, slotWidth)];
+      return [ellipsize(props.font, props.size, text, slotWidth, props.letterSpacing ?? 0)];
     }
     return text.split(/\r?\n/);
   }
-  const all = wrapText(props.font, props.size, text, props.width, { wrap: props.wrap });
+  const all = wrapText(props.font, props.size, text, props.width, { wrap: props.wrap, letterSpacing: props.letterSpacing ?? 0 });
   if (!props.maxLines || all.length <= props.maxLines) return all;
   const kept = all.slice(0, props.maxLines);
   const last = kept[kept.length - 1];
   if (last !== undefined) {
-    kept[kept.length - 1] = ellipsize(props.font, props.size, last + "…", props.width);
+    kept[kept.length - 1] = ellipsize(props.font, props.size, last + "…", props.width, props.letterSpacing ?? 0);
   }
   return kept;
 }

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -14,16 +14,21 @@ type StackOptions = BoxStyle & {
   gap?: number;
   justify?: Justify;
   align?: CrossAxis;
+  wrap?: boolean;
+};
+
+type FlexItemOptions = {
+  alignSelf?: CrossAxis;
 };
 
 export function vstack(options: StackOptions, ...children: Node[]): Node {
-  const { gap = 0, justify = "start", align = "start", ...style } = options;
+  const { gap = 0, justify = "start", align = "start", wrap: _wrap, ...style } = options;
   return { kind: "vstack", children, style, gap, justify, align };
 }
 
 export function hstack(options: StackOptions, ...children: Node[]): Node {
-  const { gap = 0, justify = "start", align = "start", ...style } = options;
-  return { kind: "hstack", children, style, gap, justify, align };
+  const { gap = 0, justify = "start", align = "start", wrap = false, ...style } = options;
+  return { kind: "hstack", children, style, gap, justify, align, wrap };
 }
 
 /** Convenience: a vstack with no styling, just to group children. */
@@ -45,7 +50,7 @@ export function keepTogether(
   return vstack({ gap, margin, breakInside: "avoid" }, ...children);
 }
 
-export interface TextOptions {
+export interface TextOptions extends FlexItemOptions {
   size: number;
   font: PDFFont;
   color?: RGB;
@@ -59,6 +64,8 @@ export interface TextOptions {
   strikethrough?: boolean;
   shrink?: number;
   breakWords?: boolean;
+  letterSpacing?: number;
+  opacity?: number;
 }
 
 export function text(content: string, options: TextOptions): Node {
@@ -75,7 +82,10 @@ export function text(content: string, options: TextOptions): Node {
     underline: options.underline,
     strikethrough: options.strikethrough,
     shrink: options.shrink,
-    breakWords: options.breakWords
+    breakWords: options.breakWords,
+    letterSpacing: options.letterSpacing,
+    opacity: options.opacity,
+    alignSelf: options.alignSelf
   };
   return { kind: "text", text: content, props };
 }
@@ -115,21 +125,23 @@ export function paragraph(options: ParagraphProps, ...runs: ParagraphItem[]): No
       paddingLeft: options.paddingLeft,
       textIndent: options.textIndent,
       wrap: options.wrap,
-      floats: options.floats
+      floats: options.floats,
+      alignSelf: options.alignSelf
     }
   };
 }
 
 export function image(
   pdfImage: PDFImage,
-  options: { width: number; height: number; margin?: EdgesInput }
+  options: { width: number; height: number; margin?: EdgesInput } & FlexItemOptions
 ): Node {
   return {
     kind: "image",
     image: pdfImage,
     width: options.width,
     height: options.height,
-    margin: options.margin
+    margin: options.margin,
+    alignSelf: options.alignSelf
   };
 }
 
@@ -140,7 +152,7 @@ export function imageFit(
     height: number;
     fit?: "contain" | "cover";
     margin?: EdgesInput;
-  }
+  } & FlexItemOptions
 ): Node {
   if (options.width <= 0 || options.height <= 0) {
     throw new Error("boxpdf imageFit: width and height must be positive");
@@ -166,7 +178,8 @@ export function imageFit(
     imageHeight: fittedHeight,
     offsetX: (options.width - fittedWidth) / 2,
     offsetY: (options.height - fittedHeight) / 2,
-    margin: options.margin
+    margin: options.margin,
+    alignSelf: options.alignSelf
   };
 }
 
@@ -181,36 +194,38 @@ export function aspectRatio(
   return { width: options.height * ratio, height: options.height };
 }
 
-export function spacer(size: number, options?: { grow?: number; shrink?: number }): Node {
-  return { kind: "spacer", size, grow: options?.grow, shrink: options?.shrink };
+export function spacer(size: number, options?: { grow?: number; shrink?: number } & FlexItemOptions): Node {
+  return { kind: "spacer", size, grow: options?.grow, shrink: options?.shrink, alignSelf: options?.alignSelf };
 }
 
 /** A flexible spacer that absorbs leftover space along the main axis. */
-export function flex(weight = 1): Node {
-  return { kind: "spacer", size: 0, grow: weight };
+export function flex(weight = 1, options?: FlexItemOptions): Node {
+  return { kind: "spacer", size: 0, grow: weight, alignSelf: options?.alignSelf };
 }
 
 export function hline(
-  options: { color: RGB; thickness?: number; width?: number; margin?: EdgesInput }
+  options: { color: RGB; thickness?: number; width?: number; margin?: EdgesInput } & FlexItemOptions
 ): Node {
   return {
     kind: "hline",
     color: options.color,
     thickness: options.thickness ?? 1,
     width: options.width,
-    margin: options.margin
+    margin: options.margin,
+    alignSelf: options.alignSelf
   };
 }
 
 export function vline(
-  options: { color: RGB; thickness?: number; height?: number; margin?: EdgesInput }
+  options: { color: RGB; thickness?: number; height?: number; margin?: EdgesInput } & FlexItemOptions
 ): Node {
   return {
     kind: "vline",
     color: options.color,
     thickness: options.thickness ?? 1,
     height: options.height,
-    margin: options.margin
+    margin: options.margin,
+    alignSelf: options.alignSelf
   };
 }
 
@@ -240,7 +255,7 @@ export function svgPath(options: {
   borderColor?: RGB;
   borderWidth?: number;
   margin?: EdgesInput;
-}): Node {
+} & FlexItemOptions): Node {
   return {
     kind: "svgPath",
     d: options.d,
@@ -250,7 +265,8 @@ export function svgPath(options: {
     color: options.color,
     borderColor: options.borderColor,
     borderWidth: options.borderWidth,
-    margin: options.margin
+    margin: options.margin,
+    alignSelf: options.alignSelf
   };
 }
 
@@ -265,8 +281,8 @@ export function svgPath(options: {
  *   )
  */
 export function link(
-  options: { href: string; margin?: EdgesInput },
+  options: { href: string; margin?: EdgesInput } & FlexItemOptions,
   child: Node
 ): Node {
-  return { kind: "link", href: options.href, child, margin: options.margin };
+  return { kind: "link", href: options.href, child, margin: options.margin, alignSelf: options.alignSelf };
 }

--- a/src/paragraph.ts
+++ b/src/paragraph.ts
@@ -1,6 +1,6 @@
 import type { PDFFont } from "pdf-lib";
-import type { Align, Node, RGB } from "./types.js";
-import { fontLineHeight, fontLineMetrics, fontXHeight, measureText } from "./text.js";
+import type { Align, CrossAxis, Node, RGB } from "./types.js";
+import { fontLineHeight, fontLineMetrics, fontXHeight, measureTextSpaced } from "./text.js";
 import { measure } from "./measure.js";
 
 export interface TextRunStyle {
@@ -10,6 +10,8 @@ export interface TextRunStyle {
   lineHeight?: number;
   underline?: boolean;
   strikethrough?: boolean;
+  letterSpacing?: number;
+  opacity?: number;
 }
 
 export interface ParagraphRun {
@@ -47,6 +49,7 @@ export interface ParagraphProps {
   textIndent?: number;
   wrap?: boolean;
   floats?: ParagraphFloat[];
+  alignSelf?: CrossAxis;
 }
 
 export interface ParagraphLineSegment {
@@ -115,9 +118,10 @@ function hardBreakRun(run: ParagraphRun, maxWidth: number): ParagraphRun[] {
   if (maxWidth <= 0) return [run];
   const out: ParagraphRun[] = [];
   let current = "";
+  const letterSpacing = run.style.letterSpacing ?? 0;
   for (const char of run.text) {
     const next = current + char;
-    if (current.length > 0 && measureText(run.style.font, run.style.size, next) > maxWidth) {
+    if (current.length > 0 && measureTextSpaced(run.style.font, run.style.size, next, letterSpacing) > maxWidth) {
       out.push({ ...run, text: current });
       current = char;
     } else {
@@ -135,7 +139,9 @@ function textStyleKey(style: TextRunStyle): string {
     style.lineHeight ?? "",
     style.underline ? "u" : "",
     style.strikethrough ? "s" : "",
-    color
+    color,
+    style.letterSpacing ?? "",
+    style.opacity ?? ""
   ].join("|");
 }
 
@@ -152,7 +158,7 @@ function segmentFromTextRun(run: ParagraphRun): ParagraphLineSegment {
     text: run.text,
     style: run.style,
     href: run.href,
-    width: measureText(run.style.font, run.style.size, run.text),
+    width: measureTextSpaced(run.style.font, run.style.size, run.text, run.style.letterSpacing ?? 0),
     height: lineHeight,
     ascent: metrics.ascent,
     descent: metrics.descent
@@ -171,7 +177,7 @@ function normalizeTextSegments(segments: ParagraphLineSegment[]): ParagraphLineS
       out[out.length - 1] = {
         ...previous,
         text,
-        width: measureText(style.font, style.size, text),
+        width: measureTextSpaced(style.font, style.size, text, style.letterSpacing ?? 0),
         height: lineHeight,
         ascent: metrics.ascent,
         descent: metrics.descent

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,10 +8,11 @@ import {
   pushGraphicsState,
   rectangle,
   rgb,
+  setCharacterSpacing,
   type PDFPage
 } from "pdf-lib";
 import { edges, type BackgroundImage, type BorderSides, type BoxStyle, type Justify, type Node, type RGB } from "./types.js";
-import { fontLineHeight, fontLineMetrics, measureText } from "./text.js";
+import { fontLineHeight, fontLineMetrics, measureTextSpaced } from "./text.js";
 import { layoutParagraph, layoutParagraphWithFloats, measureParagraphIntrinsicWidthWithIndent } from "./paragraph.js";
 import {
   layoutText,
@@ -20,6 +21,7 @@ import {
   nodeGrow,
   nodeMargin,
   nodeBaselineOffset,
+  nodeAlignSelf,
   resolveMainAxis,
   stretchCrossAxisChildren
 } from "./measure.js";
@@ -30,6 +32,7 @@ export interface RenderOptions {
 }
 
 let currentOptions: RenderOptions = {};
+let currentOpacity = 1;
 
 interface ContainingBlock {
   x: number;
@@ -44,6 +47,15 @@ function isAbsoluteBox(node: Node): node is Extract<Node, { kind: "vstack" | "hs
 
 function toRgb(color: RGB | undefined): ReturnType<typeof rgb> | undefined {
   return color ? rgb(color.r, color.g, color.b) : undefined;
+}
+
+function currentOpacityValue(): number | undefined {
+  return currentOpacity !== 1 ? currentOpacity : undefined;
+}
+
+function combinedOpacity(opacity: number | undefined): number | undefined {
+  const value = currentOpacity * (opacity ?? 1);
+  return value !== 1 ? value : undefined;
 }
 
 const DEBUG_STROKE: RGB = { r: 1, g: 0.2, b: 0.2 };
@@ -62,10 +74,12 @@ export function render(
   options: RenderOptions = {}
 ): number {
   currentOptions = options;
+  currentOpacity = 1;
   try {
     return renderWithCurrent(node, page, x, yTop, parentWidth);
   } finally {
     currentOptions = {};
+    currentOpacity = 1;
   }
 }
 
@@ -93,7 +107,23 @@ function renderWithCurrent(
   const innerX = x + m.left;
   const innerYTop = yTop - m.top;
   const innerParentWidth = parentWidth - m.left - m.right;
-  const consumed = renderContent(node, page, innerX, innerYTop, innerParentWidth, containingBlock);
+
+  // Handle opacity for stack nodes
+  const nodeOpacity = (node.kind === "vstack" || node.kind === "hstack") ? node.style.opacity : undefined;
+  const prevOpacity = currentOpacity;
+  if (nodeOpacity !== undefined) {
+    currentOpacity = currentOpacity * nodeOpacity;
+  }
+
+  let consumed: number;
+  try {
+    consumed = renderContent(node, page, innerX, innerYTop, innerParentWidth, containingBlock);
+  } finally {
+    if (nodeOpacity !== undefined) {
+      currentOpacity = prevOpacity;
+    }
+  }
+
   if (currentOptions.debug) {
     strokeDebugRect(page, innerX, innerYTop, parentWidth - m.left - m.right, consumed, DEBUG_STROKE);
   }
@@ -140,31 +170,37 @@ function renderContent(
       const { props } = node;
       const lines = layoutText(node, props.width ?? parentWidth);
       const lineHeight = props.lineHeight ?? fontLineHeight(props.font, props.size);
-      const slotWidth = props.width ?? measureText(props.font, props.size, node.text);
+      const slotWidth = props.width ?? measureTextSpaced(props.font, props.size, node.text, props.letterSpacing ?? 0);
       const decorationThickness = Math.max(0.5, props.size * 0.06);
       const decorationColor = toRgb(props.color);
+      const charSpacing = props.letterSpacing ?? 0;
+      const textOpacity = combinedOpacity(props.opacity);
       let cursorY = yTop;
       for (let i = 0; i < lines.length; i += 1) {
         const line = lines[i] ?? "";
-        const lineWidth = measureText(props.font, props.size, line);
+        const lineWidth = measureTextSpaced(props.font, props.size, line, charSpacing);
         let drawX = x;
         if (props.align === "center") drawX = x + (slotWidth - lineWidth) / 2;
         else if (props.align === "right") drawX = x + (slotWidth - lineWidth);
         const baseline = cursorY - fontLineMetrics(props.font, props.size, lineHeight).ascent;
+        if (charSpacing !== 0) page.pushOperators(setCharacterSpacing(charSpacing));
         page.drawText(line, {
           x: drawX,
           y: baseline,
           size: props.size,
           font: props.font,
-          color: toRgb(props.color)
+          color: toRgb(props.color),
+          opacity: textOpacity
         });
+        if (charSpacing !== 0) page.pushOperators(setCharacterSpacing(0));
         if (props.underline && line.length > 0) {
           const underlineY = baseline - Math.max(1, props.size * 0.12);
           page.drawLine({
             start: { x: drawX, y: underlineY },
             end: { x: drawX + lineWidth, y: underlineY },
             thickness: decorationThickness,
-            color: decorationColor
+            color: decorationColor,
+            opacity: textOpacity
           });
         }
         if (props.strikethrough && line.length > 0) {
@@ -173,7 +209,8 @@ function renderContent(
             start: { x: drawX, y: midY },
             end: { x: drawX + lineWidth, y: midY },
             thickness: decorationThickness,
-            color: decorationColor
+            color: decorationColor,
+            opacity: textOpacity
           });
         }
         cursorY -= lineHeight;
@@ -205,13 +242,18 @@ function renderContent(
         const baseline = cursorY - lineAscent;
         for (const segment of line.segments) {
           if (segment.kind === "text" && segment.text !== undefined && segment.style !== undefined) {
+            const segCharSpacing = segment.style.letterSpacing ?? 0;
+            const segOpacity = combinedOpacity(segment.style.opacity);
+            if (segCharSpacing !== 0) page.pushOperators(setCharacterSpacing(segCharSpacing));
             page.drawText(segment.text, {
               x: drawX,
               y: baseline,
               size: segment.style.size,
               font: segment.style.font,
-              color: toRgb(segment.style.color)
+              color: toRgb(segment.style.color),
+              opacity: segOpacity
             });
+            if (segCharSpacing !== 0) page.pushOperators(setCharacterSpacing(0));
             const decorationThickness = Math.max(0.5, segment.style.size * 0.06);
             const decorationColor = toRgb(segment.style.color);
             if (segment.style.underline && segment.text.length > 0) {
@@ -220,7 +262,8 @@ function renderContent(
                 start: { x: drawX, y: underlineY },
                 end: { x: drawX + segment.width, y: underlineY },
                 thickness: decorationThickness,
-                color: decorationColor
+                color: decorationColor,
+                opacity: segOpacity
               });
             }
             if (segment.style.strikethrough && segment.text.length > 0) {
@@ -229,7 +272,8 @@ function renderContent(
                 start: { x: drawX, y: midY },
                 end: { x: drawX + segment.width, y: midY },
                 thickness: decorationThickness,
-                color: decorationColor
+                color: decorationColor,
+                opacity: segOpacity
               });
             }
           } else if (segment.kind === "inline" && segment.node !== undefined) {
@@ -256,7 +300,8 @@ function renderContent(
         x,
         y: yTop - node.height,
         width: node.width,
-        height: node.height
+        height: node.height,
+        opacity: currentOpacityValue()
       });
       return node.height;
     case "imageBox": {
@@ -270,7 +315,8 @@ function renderContent(
         x: x + node.offsetX,
         y: yTop - node.offsetY - node.imageHeight,
         width: node.imageWidth,
-        height: node.imageHeight
+        height: node.imageHeight,
+        opacity: currentOpacityValue()
       });
       page.pushOperators(popGraphicsState());
       return node.height;
@@ -284,7 +330,8 @@ function renderContent(
         start: { x, y },
         end: { x: x + w, y },
         thickness: node.thickness,
-        color: toRgb(node.color)
+        color: toRgb(node.color),
+        opacity: currentOpacityValue()
       });
       return node.thickness;
     }
@@ -295,7 +342,8 @@ function renderContent(
         start: { x: lineX, y: yTop },
         end: { x: lineX, y: yTop - h },
         thickness: node.thickness,
-        color: toRgb(node.color)
+        color: toRgb(node.color),
+        opacity: currentOpacityValue()
       });
       return h;
     }
@@ -315,7 +363,9 @@ function renderContent(
         scale: node.scale,
         color: toRgb(node.color),
         borderColor: toRgb(node.borderColor),
-        borderWidth: node.borderWidth
+        borderWidth: node.borderWidth,
+        opacity: currentOpacityValue(),
+        borderOpacity: currentOpacityValue()
       });
       return node.height;
     }
@@ -366,7 +416,9 @@ function renderVStack(
   const inset = edges(node.style.padding);
   const intrinsic = measureContent(node, parentWidth);
   const boxWidth = node.style.width ?? intrinsic.width;
-  const boxHeight = node.style.height ?? intrinsic.height;
+  let boxHeight = node.style.height ?? intrinsic.height;
+  if (node.style.maxHeight !== undefined) boxHeight = Math.min(boxHeight, node.style.maxHeight);
+  if (node.style.minHeight !== undefined) boxHeight = Math.max(boxHeight, node.style.minHeight);
   const flowChildren = stretchCrossAxisChildren(
     node.children.filter((child) => !isAbsoluteBox(child)),
     "vertical",
@@ -392,7 +444,7 @@ function renderVStack(
   // Resolve shrink first so children that overflow the main axis get
   // re-sized before grow/justify positioning runs. When the vstack has no
   // fixed height, no overflow is possible so shrink is a no-op.
-  const availableMain = node.style.height === undefined ? Infinity : innerHeight;
+  const availableMain = node.style.height === undefined && node.style.maxHeight === undefined ? Infinity : innerHeight;
   const layout = resolveMainAxis(flowChildren, "vertical", availableMain, innerWidth, node.gap);
   const children = layout.children;
   const childSizes = layout.sizes;
@@ -418,7 +470,8 @@ function renderVStack(
       children.forEach((child, i) => {
         const slotHeight = childSizes[i]?.height ?? 0;
         const widthForChild = resolveCrossAxisWidth(child, childSizes[i]?.width ?? 0, innerWidth);
-        const childX = resolveCrossAxisX(node.align, innerX, innerWidth, widthForChild);
+        const effectiveAlign = nodeAlignSelf(child) ?? node.align;
+        const childX = resolveCrossAxisX(effectiveAlign, innerX, innerWidth, widthForChild);
         renderWithFixedHeight(child, page, childX, cursorY, widthForChild, slotHeight, childContainingBlock);
         cursorY -= slotHeight;
         if (i < children.length - 1) cursorY -= offsets.between;
@@ -429,7 +482,8 @@ function renderVStack(
         const baseHeight = childSizes[i]?.height ?? 0;
         const slotHeight = baseHeight + (extraPerChild[i] ?? 0);
         const widthForChild = resolveCrossAxisWidth(child, childSizes[i]?.width ?? 0, innerWidth);
-        const childX = resolveCrossAxisX(node.align, innerX, innerWidth, widthForChild);
+        const effectiveAlign = nodeAlignSelf(child) ?? node.align;
+        const childX = resolveCrossAxisX(effectiveAlign, innerX, innerWidth, widthForChild);
         renderWithFixedHeight(child, page, childX, cursorY, widthForChild, slotHeight, childContainingBlock);
         cursorY -= slotHeight;
       });
@@ -452,7 +506,9 @@ function renderHStack(
   const inset = edges(node.style.padding);
   const intrinsic = measureContent(node, parentWidth);
   const boxWidth = node.style.width ?? intrinsic.width;
-  const boxHeight = node.style.height ?? intrinsic.height;
+  let boxHeight = node.style.height ?? intrinsic.height;
+  if (node.style.maxHeight !== undefined) boxHeight = Math.min(boxHeight, node.style.maxHeight);
+  if (node.style.minHeight !== undefined) boxHeight = Math.max(boxHeight, node.style.minHeight);
   const flowChildren = stretchCrossAxisChildren(
     node.children.filter((child) => !isAbsoluteBox(child)),
     "horizontal",
@@ -493,6 +549,50 @@ function renderHStack(
 
   let cursorX = innerX;
   withBoxOverflowClip(page, node.style, x, yTop, boxWidth, boxHeight, () => {
+    if (node.wrap) {
+      // Greedy row bin-packing rendering
+      const flowChildren = node.children.filter((child) => !isAbsoluteBox(child));
+      const childSizesWrap = flowChildren.map((child) => measure(child, innerWidth));
+      const rows: Array<{ indices: number[]; rowHeight: number }> = [];
+      let rowIndices: number[] = [];
+      let rowWidth = 0;
+      for (let i = 0; i < flowChildren.length; i++) {
+        const w = childSizesWrap[i]!.width;
+        const addGap = rowIndices.length > 0 ? node.gap : 0;
+        if (rowIndices.length > 0 && rowWidth + addGap + w > innerWidth) {
+          const rowHeight = rowIndices.reduce((m, idx) => Math.max(m, childSizesWrap[idx]!.height), 0);
+          rows.push({ indices: rowIndices, rowHeight });
+          rowIndices = [i];
+          rowWidth = w;
+        } else {
+          rowIndices.push(i);
+          rowWidth += addGap + w;
+        }
+      }
+      if (rowIndices.length > 0) {
+        const rowHeight = rowIndices.reduce((m, idx) => Math.max(m, childSizesWrap[idx]!.height), 0);
+        rows.push({ indices: rowIndices, rowHeight });
+      }
+      let rowCursorY = innerYTop;
+      for (const row of rows) {
+        // Render each row as a synthetic ephemeral hstack
+        const rowChildren = row.indices.map((i) => flowChildren[i]!);
+        const syntheticRow: Extract<Node, { kind: "hstack" }> = {
+          kind: "hstack",
+          children: rowChildren,
+          style: { width: innerWidth, height: row.rowHeight },
+          gap: node.gap,
+          justify: node.justify,
+          align: node.align,
+          wrap: false
+        };
+        renderHStack(syntheticRow, page, innerX, rowCursorY, innerWidth, childContainingBlock);
+        rowCursorY -= row.rowHeight + node.gap;
+      }
+      renderAbsoluteChildren(absoluteChildren, page, childContainingBlock);
+      return;
+    }
+
     if (totalGrow === 0) {
       const offsets = computeMainAxisOffsets(
         node.justify,
@@ -504,8 +604,9 @@ function renderHStack(
       children.forEach((child, i) => {
         const slotWidth = childSizes[i]?.width ?? 0;
         const heightForChild = resolveCrossAxisHeight(child, childSizes[i]?.height ?? 0, innerHeight);
+        const effectiveAlign = nodeAlignSelf(child) ?? node.align;
         const childY = resolveCrossAxisY(
-          node.align,
+          effectiveAlign,
           innerYTop,
           innerHeight,
           heightForChild,
@@ -526,8 +627,9 @@ function renderHStack(
         const baseWidth = childSizes[i]?.width ?? 0;
         const slotWidth = baseWidth + (extraPerChild[i] ?? 0);
         const heightForChild = resolveCrossAxisHeight(child, childSizes[i]?.height ?? 0, innerHeight);
+        const effectiveAlign = nodeAlignSelf(child) ?? node.align;
         const childY = resolveCrossAxisY(
-          node.align,
+          effectiveAlign,
           innerYTop,
           innerHeight,
           heightForChild,
@@ -761,15 +863,17 @@ function drawBackground(
 ): void {
   if (!color) return;
   const yBottom = yTop - height;
+  const opacity = currentOpacityValue();
   if (!radius || radius <= 0) {
-    page.drawRectangle({ x, y: yBottom, width, height, color: toRgb(color) });
+    page.drawRectangle({ x, y: yBottom, width, height, color: toRgb(color), opacity });
     return;
   }
   page.drawSvgPath(roundedRectPath(width, height, radius), {
     x,
     y: yTop,
     color: toRgb(color),
-    borderWidth: 0
+    borderWidth: 0,
+    opacity
   });
 }
 
@@ -797,7 +901,8 @@ function drawBackgroundImage(
         x: x + tileX,
         y: yTop - tileY - backgroundImage.height,
         width: backgroundImage.width,
-        height: backgroundImage.height
+        height: backgroundImage.height,
+        opacity: currentOpacityValue()
       });
     }
   }
@@ -827,7 +932,8 @@ function drawBorder(
       width,
       height,
       borderColor: toRgb(border.color),
-      borderWidth: border.width
+      borderWidth: border.width,
+      borderOpacity: currentOpacityValue()
     });
     return;
   }
@@ -835,7 +941,8 @@ function drawBorder(
     x,
     y: yTop,
     borderColor: toRgb(border.color),
-    borderWidth: border.width
+    borderWidth: border.width,
+    borderOpacity: currentOpacityValue()
   });
 }
 
@@ -855,7 +962,8 @@ function drawBorderSides(
       start: { x, y },
       end: { x: x + width, y },
       thickness: borderSides.top.width,
-      color: toRgb(borderSides.top.color)
+      color: toRgb(borderSides.top.color),
+      opacity: currentOpacityValue()
     });
   }
   if (borderSides.right) {
@@ -864,7 +972,8 @@ function drawBorderSides(
       start: { x: lineX, y: yTop },
       end: { x: lineX, y: yBottom },
       thickness: borderSides.right.width,
-      color: toRgb(borderSides.right.color)
+      color: toRgb(borderSides.right.color),
+      opacity: currentOpacityValue()
     });
   }
   if (borderSides.bottom) {
@@ -873,7 +982,8 @@ function drawBorderSides(
       start: { x, y },
       end: { x: x + width, y },
       thickness: borderSides.bottom.width,
-      color: toRgb(borderSides.bottom.color)
+      color: toRgb(borderSides.bottom.color),
+      opacity: currentOpacityValue()
     });
   }
   if (borderSides.left) {
@@ -882,7 +992,8 @@ function drawBorderSides(
       start: { x: lineX, y: yTop },
       end: { x: lineX, y: yBottom },
       thickness: borderSides.left.width,
-      color: toRgb(borderSides.left.color)
+      color: toRgb(borderSides.left.color),
+      opacity: currentOpacityValue()
     });
   }
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -41,6 +41,15 @@ export function measureText(font: PDFFont, size: number, value: string): number 
   return font.widthOfTextAtSize(value, size);
 }
 
+export function measureTextSpaced(
+  font: PDFFont,
+  size: number,
+  value: string,
+  letterSpacing = 0
+): number {
+  return measureText(font, size, value) + letterSpacing * Math.max(0, value.length - 1);
+}
+
 type FontkitEmbedder = {
   font?: {
     unitsPerEm?: number;
@@ -58,10 +67,11 @@ export function wrapText(
   size: number,
   value: string,
   maxWidth: number,
-  options: { wrap?: boolean } = {}
+  options: { wrap?: boolean; letterSpacing?: number } = {}
 ): string[] {
   if (maxWidth <= 0) return [value];
   if (options.wrap === false) return value.split(/\r?\n/);
+  const letterSpacing = options.letterSpacing ?? 0;
   const lines: string[] = [];
   for (const paragraph of value.split(/\r?\n/)) {
     if (paragraph.length === 0) {
@@ -72,7 +82,7 @@ export function wrapText(
     let current = "";
     for (const word of words) {
       const candidate = current + word;
-      const width = measureText(font, size, candidate);
+      const width = measureTextSpaced(font, size, candidate, letterSpacing);
       if (width <= maxWidth) {
         current = candidate;
         continue;
@@ -80,10 +90,10 @@ export function wrapText(
       if (current.length > 0) {
         lines.push(current.replace(/\s+$/, ""));
         current = word.replace(/^\s+/, "");
-        if (measureText(font, size, current) <= maxWidth) continue;
+        if (measureTextSpaced(font, size, current, letterSpacing) <= maxWidth) continue;
       }
       // current is empty or the single word is too wide; hard-break by char
-      const hardBroken = hardBreak(font, size, current.length > 0 ? current : word, maxWidth);
+      const hardBroken = hardBreak(font, size, current.length > 0 ? current : word, maxWidth, letterSpacing);
       lines.push(...hardBroken.slice(0, -1));
       const tail = hardBroken[hardBroken.length - 1];
       current = tail ?? "";
@@ -93,12 +103,18 @@ export function wrapText(
   return lines.length === 0 ? [""] : lines;
 }
 
-function hardBreak(font: PDFFont, size: number, value: string, maxWidth: number): string[] {
+function hardBreak(
+  font: PDFFont,
+  size: number,
+  value: string,
+  maxWidth: number,
+  letterSpacing: number
+): string[] {
   const out: string[] = [];
   let current = "";
   for (const char of value) {
     const next = current + char;
-    if (measureText(font, size, next) > maxWidth && current.length > 0) {
+    if (measureTextSpaced(font, size, next, letterSpacing) > maxWidth && current.length > 0) {
       out.push(current);
       current = char;
     } else {
@@ -109,16 +125,22 @@ function hardBreak(font: PDFFont, size: number, value: string, maxWidth: number)
   return out;
 }
 
-export function ellipsize(font: PDFFont, size: number, value: string, maxWidth: number): string {
-  if (measureText(font, size, value) <= maxWidth) return value;
+export function ellipsize(
+  font: PDFFont,
+  size: number,
+  value: string,
+  maxWidth: number,
+  letterSpacing = 0
+): string {
+  if (measureTextSpaced(font, size, value, letterSpacing) <= maxWidth) return value;
   const ellipsis = "…";
-  const ellipsisWidth = measureText(font, size, ellipsis);
+  const ellipsisWidth = measureTextSpaced(font, size, ellipsis, letterSpacing);
   if (ellipsisWidth > maxWidth) return "";
   let lo = 0;
   let hi = value.length;
   while (lo < hi) {
     const mid = Math.floor((lo + hi + 1) / 2);
-    if (measureText(font, size, value.slice(0, mid)) + ellipsisWidth <= maxWidth) {
+    if (measureTextSpaced(font, size, value.slice(0, mid) + ellipsis, letterSpacing) <= maxWidth) {
       lo = mid;
     } else {
       hi = mid - 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,10 @@ export interface BoxStyle {
   width?: number;
   /** Fixed height; if omitted, the box sizes to its content. */
   height?: number;
+  /** Minimum height; the box will grow to at least this height. */
+  minHeight?: number;
+  /** Maximum height; the box will shrink to at most this height. */
+  maxHeight?: number;
   /** Inner spacing between the box's border and its children. */
   padding?: EdgesInput;
   /** Outer spacing around the box. */
@@ -76,6 +80,8 @@ export interface BoxStyle {
    * values. Boxes with the same `zIndex` keep document order. Default `0`.
    */
   zIndex?: number;
+  /** Cross-axis alignment override for this child within its parent stack. */
+  alignSelf?: CrossAxis;
   /** Flex grow weight (siblings divide remaining main-axis space proportionally). */
   grow?: number;
   /**
@@ -88,9 +94,16 @@ export interface BoxStyle {
   shrink?: number;
   /** Page fragmentation hint. `avoid` keeps the box atomic under renderFlow. */
   breakInside?: BreakInside;
+  /** Alpha transparency, 0 = fully transparent, 1 = fully opaque. */
+  opacity?: number;
 }
 
-export interface TextProps {
+export interface FlexItemStyle {
+  /** Cross-axis alignment override for this child within its parent stack. */
+  alignSelf?: CrossAxis;
+}
+
+export interface TextProps extends FlexItemStyle {
   size: number;
   font: PDFFont;
   color?: RGB;
@@ -125,6 +138,10 @@ export interface TextProps {
    * truncation, this for char-level wrap (monospace tables, hashes).
    */
   breakWords?: boolean;
+  /** Extra space added between each character in points. */
+  letterSpacing?: number;
+  /** Alpha transparency, 0 = fully transparent, 1 = fully opaque. */
+  opacity?: number;
 }
 
 export type Node =
@@ -144,6 +161,7 @@ export type Node =
       gap: number;
       justify: Justify;
       align: CrossAxis;
+      wrap?: boolean;
     }
   | {
       kind: "text";
@@ -161,6 +179,7 @@ export type Node =
       width: number;
       height: number;
       margin?: EdgesInput;
+      alignSelf?: CrossAxis;
     }
   | {
       kind: "imageBox";
@@ -172,12 +191,14 @@ export type Node =
       offsetX: number;
       offsetY: number;
       margin?: EdgesInput;
+      alignSelf?: CrossAxis;
     }
   | {
       kind: "spacer";
       size: number;
       grow?: number;
       shrink?: number;
+      alignSelf?: CrossAxis;
     }
   | {
       kind: "hline";
@@ -185,6 +206,7 @@ export type Node =
       thickness: number;
       width?: number;
       margin?: EdgesInput;
+      alignSelf?: CrossAxis;
     }
   | {
       kind: "vline";
@@ -192,12 +214,14 @@ export type Node =
       thickness: number;
       height?: number;
       margin?: EdgesInput;
+      alignSelf?: CrossAxis;
     }
   | {
       kind: "link";
       href: string;
       child: Node;
       margin?: EdgesInput;
+      alignSelf?: CrossAxis;
     }
   | {
       kind: "svgPath";
@@ -216,6 +240,7 @@ export type Node =
       /** Border / stroke width. */
       borderWidth?: number;
       margin?: EdgesInput;
+      alignSelf?: CrossAxis;
     };
 
 export interface Size {

--- a/test/measure.test.ts
+++ b/test/measure.test.ts
@@ -35,6 +35,16 @@ describe("measure", () => {
     expect(w.height).toBeGreaterThan(u.height);
   });
 
+  it("includes letterSpacing in text intrinsic width and wrapping", () => {
+    const compact = text("abcdef", { size: 12, font });
+    const spaced = text("abcdef", { size: 12, font, letterSpacing: 3 });
+    expect(measure(spaced, 500).width - measure(compact, 500).width).toBeCloseTo(15, 5);
+
+    const oneLine = measure(text("abcdef", { size: 12, font, width: 50, letterSpacing: 0 }), 500);
+    const wrapped = measure(text("abcdef", { size: 12, font, width: 50, letterSpacing: 10 }), 500);
+    expect(wrapped.height).toBeGreaterThan(oneLine.height);
+  });
+
   it("vstack sums child heights plus gaps", () => {
     const node = vstack(
       { gap: 5 },
@@ -80,6 +90,15 @@ describe("measure", () => {
   it("fixed width on a vstack overrides intrinsic", () => {
     const node = vstack({ width: 300 }, text("x", { size: 10, font: bold }));
     expect(measure(node, 100).width).toBe(300);
+  });
+
+  it("uses maxHeight as a vertical shrink constraint", () => {
+    const parent = vstack(
+      { maxHeight: 50 },
+      vstack({ height: 80, shrink: 1 })
+    );
+
+    expect(measure(parent, 100).height).toBe(50);
   });
 
   it("can memoize repeated measurements within an explicit cache scope", () => {

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -59,6 +59,23 @@ describe("render", () => {
     expect(bytes.byteLength).toBeGreaterThan(100);
   });
 
+  it("wrapped hstack applies justify within each full-width row", async () => {
+    const pdf = await PDFDocument.create();
+    const page = pdf.addPage([240, 140]);
+    const drawText = vi.spyOn(page, "drawText");
+    const node = hstack(
+      { width: 100, wrap: true, justify: "end", gap: 0 },
+      text("A", { size: 12, font }),
+      text("B", { size: 12, font }),
+      text("C", { size: 12, font })
+    );
+
+    render(node, page, 20, 120, 200);
+
+    const first = drawText.mock.calls.find((call) => call[0] === "A");
+    expect(first?.[1]?.x).toBeGreaterThan(20);
+  });
+
   it("vstack with flex grow stretches a spacer to absorb extra height", async () => {
     const pdf = await PDFDocument.create();
     const page = pdf.addPage([200, 400]);
@@ -90,6 +107,21 @@ describe("render", () => {
     expect(drawRectangle).toHaveBeenCalledWith(
       expect.objectContaining({ x: 10, y: 80, width: 120, height: 20 })
     );
+  });
+
+  it("alignSelf overrides stretch for text children", async () => {
+    const pdf = await PDFDocument.create();
+    const page = pdf.addPage([200, 120]);
+    const drawText = vi.spyOn(page, "drawText");
+    const node = vstack(
+      { width: 120, align: "stretch" },
+      text("centered", { size: 10, font, alignSelf: "center" })
+    );
+
+    render(node, page, 10, 100, 200);
+
+    const call = drawText.mock.calls.find((entry) => entry[0] === "centered");
+    expect(call?.[1]?.x).toBeGreaterThan(10);
   });
 
   it("hstack align:stretch gives auto-height children the full cross-axis height", async () => {
@@ -160,6 +192,46 @@ describe("render", () => {
       )
     );
     expect(bytes.byteLength).toBeGreaterThan(200);
+  });
+
+  it("applies stack opacity to descendants and text decorations", async () => {
+    const pdf = await PDFDocument.create();
+    const page = pdf.addPage([240, 160]);
+    const drawText = vi.spyOn(page, "drawText");
+    const drawLine = vi.spyOn(page, "drawLine");
+    const drawRectangle = vi.spyOn(page, "drawRectangle");
+    const node = vstack(
+      {
+        width: 120,
+        opacity: 0.5,
+        background: hex("#eeeeee"),
+        border: { color: hex("#111111"), width: 1 }
+      },
+      text("Faded", { size: 12, font, underline: true, opacity: 0.5 })
+    );
+
+    render(node, page, 10, 140, 200);
+
+    expect(drawRectangle).toHaveBeenCalledWith(expect.objectContaining({ opacity: 0.5 }));
+    expect(drawRectangle).toHaveBeenCalledWith(expect.objectContaining({ borderOpacity: 0.5 }));
+    expect(drawText.mock.calls.find((call) => call[0] === "Faded")?.[1]?.opacity).toBe(0.25);
+    expect(drawLine.mock.calls[0]?.[0]?.opacity).toBe(0.25);
+  });
+
+  it("maxHeight constrains vertical shrink during render", async () => {
+    const pdf = await PDFDocument.create();
+    const page = pdf.addPage([200, 160]);
+    const drawRectangle = vi.spyOn(page, "drawRectangle");
+    const node = vstack(
+      { maxHeight: 50 },
+      vstack({ height: 80, shrink: 1, background: hex("#ddeeff") })
+    );
+
+    render(node, page, 10, 140, 200);
+
+    expect(drawRectangle).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 10, y: 90, width: 0, height: 50 })
+    );
   });
 
   it("draws per-side borders inside the box bounds", async () => {


### PR DESCRIPTION
## Release notes

### boxpdf 1.8.0

This release makes core layout and rendering behavior more CSS-like for common document-generation cases.

- Adds `hstack({ wrap: true })` support with per-row justification.
- Adds stack `minHeight` and `maxHeight`, including vertical shrink constraints for `maxHeight`.
- Adds `alignSelf` across flex items, including text, paragraphs, spacers, lines, images, links, and SVG paths.
- Adds layout-aware `letterSpacing` for text and paragraph runs, including measurement, wrapping, hard-breaking, ellipsizing, alignment, and decorations.
- Adds CSS-style opacity propagation from stack nodes to descendants and applies text opacity to underline/strikethrough decorations.

## Why

These APIs previously existed only partially or behaved like paint-time tweaks. The result was surprising compared with CSS and other layout systems: spaced text measured too narrow, wrapped rows could not justify against the full row, `maxHeight` clipped without constraining shrink layout, and opacity did not affect descendants consistently.

## Validation

- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`