### PR TITLE
Fix first-child page overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxpdf",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "mcpName": "io.github.earonesty/boxpdf",
   "description": "Tiny box-layout DSL over pdf-lib. Flexbox-lite for server-side PDF generation in any JS runtime (Node, Cloudflare Workers, Deno, browsers).",
   "keywords": [

--- a/src/document.ts
+++ b/src/document.ts
@@ -157,7 +157,7 @@ function splitNormalStack(
   let splitAt = 0;
   for (let i = 0; i < node.children.length; i += 1) {
     const candidate = cloneStackWithChildren(node, node.children.slice(0, i + 1));
-    if (measure(candidate, contentWidth).height <= availableHeight || i === 0) {
+    if (measure(candidate, contentWidth).height <= availableHeight) {
       splitAt = i + 1;
       continue;
     }
@@ -186,7 +186,7 @@ function splitTableStack(
   let splitAt = 0;
   for (let i = 0; i < body.length; i += 1) {
     const candidate = cloneStackWithChildren(node, [...header, ...body.slice(0, i + 1)]);
-    if (measure(candidate, contentWidth).height <= availableHeight || i === 0) {
+    if (measure(candidate, contentWidth).height <= availableHeight) {
       splitAt = i + 1;
       continue;
     }

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -396,6 +396,38 @@ describe("render", () => {
     expect(pages.length).toBeGreaterThan(1);
   });
 
+  it("moves a fragmentable stack when its first child cannot fit", async () => {
+    const pdf = await PDFDocument.create();
+    const phases: string[] = [];
+    const filler = spacer(100);
+    const photoCard = vstack(
+      { gap: 4 },
+      vstack(
+        { height: 100, background: hex("#eeeeee") },
+        text("photo", { size: 10, font })
+      ),
+      text("caption", { size: 10, font })
+    );
+
+    const { pages } = await renderFlow(pdf, [filler, photoCard], {
+      size: { width: 240, height: 220 },
+      margin: 20,
+      profile: (event) => {
+        if (["split-start", "node-render-start", "page-break"].includes(event.phase)) {
+          phases.push(event.phase);
+        }
+      }
+    });
+
+    expect(pages).toHaveLength(2);
+    expect(phases).toEqual([
+      "node-render-start",
+      "split-start",
+      "page-break",
+      "node-render-start"
+    ]);
+  });
+
   it("fragments tables between rows and repeats the header", async () => {
     const drawText = vi.spyOn(PDFPage.prototype, "drawText");
     try {
@@ -430,6 +462,39 @@ describe("render", () => {
     } finally {
       drawText.mockRestore();
     }
+  });
+
+  it("moves a table when its first row cannot fit", async () => {
+    const pdf = await PDFDocument.create();
+    const phases: string[] = [];
+    const node = table({
+      width: 180,
+      columns: [{ width: "1fr" }],
+      header: [text("Item", { size: 10, font: bold })],
+      rows: [
+        [vstack({ height: 70 }, text("Row 1", { size: 10, font }))],
+        [vstack({ height: 40 }, text("Row 2", { size: 10, font }))]
+      ],
+      cellPadding: 0
+    });
+
+    const { pages } = await renderFlow(pdf, [spacer(145), node], {
+      size: { width: 240, height: 260 },
+      margin: 20,
+      profile: (event) => {
+        if (["split-start", "node-render-start", "page-break"].includes(event.phase)) {
+          phases.push(event.phase);
+        }
+      }
+    });
+
+    expect(pages).toHaveLength(2);
+    expect(phases).toEqual([
+      "node-render-start",
+      "split-start",
+      "page-break",
+      "node-render-start"
+    ]);
   });
 
   it("hline takes parent width when no width supplied", async () => {


### PR DESCRIPTION
## What changed

- refuse stack fragmentation when the first child does not fit in the remaining page space
- apply the same rule to table row fragmentation
- add regression coverage for photo-card-style stacks and tables
- bump the package version from 1.9.0 to 1.9.1

## Why

The splitters previously forced the first child or row into the current page even when its measured height exceeded the remaining space. That could draw an image past the page boundary and make it appear cropped, while moving only its caption to the next page.

The paginator now returns no split when nothing fits, allowing the outer flow logic to move the complete node to a fresh page. Content taller than a completely empty page still renders once rather than causing a pagination loop.

## Validation

- `pnpm run typecheck`
- `pnpm run test` (171 tests)
- `pnpm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination behavior when the first content item cannot fit on the current page.
  * Prevented fragmentable stacks and tables from splitting incorrectly, ensuring they move cleanly to the next page when needed.

* **Tests**
  * Added regression coverage for stack and table pagination scenarios.

* **Chores**
  * Updated the package version to 1.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->