### PR TITLE
Pin release workflow to npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Upgrade npm
         # OIDC-based trusted publishing requires npm >= 11.5.1. Node 20's
-        # bundled npm is 10.x, which silently falls back to anonymous PUTs
-        # and yields a confusing 404 "not in this registry."
-        run: npm install -g npm@latest
+        # bundled npm is 10.x, while npm 12 requires Node 22. Pin the major so
+        # npm upgrades cannot silently make the Node 20 release job invalid.
+        run: npm install -g npm@11
 
       - name: Install
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What changed

- pin the release workflow to npm 11 instead of `npm@latest`
- document the Node 20 compatibility constraint

## Why

The `v1.9.1` release run resolved `npm@latest` to npm 12.0.1, which requires Node 22.22.2 or newer. The release job intentionally runs Node 20, so it failed at the npm upgrade step before installing dependencies or publishing anything.

npm 11 supports Node 20 and satisfies npm trusted publishing's npm 11.5.1 minimum.

## Validation

- `git diff --check`
- `pnpm run typecheck`
- `pnpm run test` (171 tests)
- `pnpm run build`
- confirmed npm 11 supports Node 20.17.0+
