### PR TITLE
Modernize release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,27 +20,22 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up pnpm
         # `version` is omitted on purpose — the action reads `packageManager`
         # from package.json. Specifying both causes ERR_PNPM_BAD_PM_VERSION.
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        # Node 24 includes an npm version new enough for OIDC trusted publishing.
+        uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm
-        # OIDC-based trusted publishing requires npm >= 11.5.1. Node 20's
-        # bundled npm is 10.x, while npm 12 requires Node 22. Pin the major so
-        # npm upgrades cannot silently make the Node 20 release job invalid.
-        run: npm install -g npm@11
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -63,6 +58,6 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
## What changed

- upgrade `actions/checkout` from v4 to v7
- upgrade `actions/setup-node` from v4 to v7
- upgrade `pnpm/action-setup` from v4 to v6
- upgrade `softprops/action-gh-release` from v2 to v3
- move the release build from Node 20 to Node 24
- use Node 24's bundled npm instead of installing a second npm globally

## Why

GitHub now warns that the old action versions target a deprecated Node 20 action runtime. All four new action majors use Node 24 internally. The release build also moves to the current Node 24 LTS line, whose bundled npm satisfies trusted publishing's npm 11.5.1 minimum.

Removing the global npm upgrade avoids the version mismatch that blocked the first v1.9.1 release attempt.

## Compatibility

This changes only GitHub's future build and publish environment. BoxPDF's source, emitted JavaScript target, package metadata, peer dependencies, and `node >=18` consumer requirement are unchanged. Existing installations and older BoxPDF versions are unaffected.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `pnpm run typecheck`
- `pnpm run test` (171 tests)
- `pnpm run build`
- `npm pack --dry-run --json`
