### PR TITLE
Stream bounded stack and table continuations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install visual dependencies
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Check streamed visual parity
+        run: pnpm run visual:check:stream

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -49,3 +53,6 @@ jobs:
 
       - name: Check streamed visual parity
         run: pnpm run visual:check:stream
+
+      - name: Check continuation memory
+        run: pnpm run memory:check:continuation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
-          version: 10.30.3
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         # `version` is omitted on purpose — the action reads `packageManager`

--- a/README.md
+++ b/README.md
@@ -371,6 +371,21 @@ Peak heap during render. Each measurement runs in its own subprocess. 50 lines o
 
 streamFlow holds peak heap roughly flat (12 → 25 MB across a 100× workload increase). renderFlow scales roughly linearly with page count. `@react-pdf/renderer` adds ~2.3 MB per page in this workload and peaks at 2.3 GB by 1000 pages. See `docs/design/streaming.md` for the design and the chart.
 
+The continuation path has its own heap-capped subprocess check. Unlike the
+older comparison above, it constructs every fragment lazily and forces a GC
+after output to distinguish V8's allocation high-water mark from the retained
+live set:
+
+| Continuation fragments | Output pages | Sampled peak heap | Retained heap after GC | Output |
+| ---: | ---: | ---: | ---: | ---: |
+| 100 | 81 | ~58 MB | ~16 MB | 129 KB |
+| 1000 | 810 | ~125 MB | ~26 MB | 1.3 MB |
+
+Both runs complete with `--max-old-space-size=128`. Across the 10× workload,
+the retained heap grows by about 10 MB, primarily from the final page tree and xref
+index; rendered page content and continuation input are released incrementally.
+Reproduce it with `pnpm memory:check:continuation`.
+
 ## Cloudflare Workers
 
 Both the core and the `boxpdf/inter` subpath run on Workers without `nodejs_compat`.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,26 @@ await streamFlow(pdf, out, nodes, {
 });
 ```
 
+If one logical stack or table is too large to construct at once, emit bounded
+pieces with `flowContinuation`. Adjacent pieces with the same id are paginated
+as though they were one node, including stack gaps, decoration, table headers,
+and row dividers:
+
+```ts
+for (let offset = 0; offset < rows.length; offset += 100) {
+  const final = offset + 100 >= rows.length;
+  yield flowContinuation(
+    table({ columns, header, rows: rows.slice(offset, offset + 100) }),
+    "orders",
+    final
+  );
+}
+```
+
+Continuation fragments must be consecutive and the last one must set
+`final: true`; `streamFlow` rejects interrupted or unfinished sequences instead
+of silently producing an incomplete layout.
+
 ### Contract
 
 1. All `embedFont` / `embedJpg` / `embedPng` calls must complete before `streamFlow`. Embedding mid-stream throws.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxpdf",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "mcpName": "io.github.earonesty/boxpdf",
   "description": "Tiny box-layout DSL over pdf-lib. Flexbox-lite for server-side PDF generation in any JS runtime (Node, Cloudflare Workers, Deno, browsers).",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "visual:check:stream": "tsx scripts/check-stream-visuals.ts",
     "example": "tsx examples/index.ts",
     "gallery": "tsx scripts/build-gallery.ts",
     "prepublishOnly": "pnpm run typecheck && pnpm run test && pnpm run build"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "visual:check:stream": "tsx scripts/check-stream-visuals.ts",
+    "memory:check:continuation": "tsx scripts/check-continuation-memory.ts",
     "example": "tsx examples/index.ts",
     "gallery": "tsx scripts/build-gallery.ts",
     "prepublishOnly": "pnpm run typecheck && pnpm run test && pnpm run build"

--- a/scripts/check-continuation-memory.ts
+++ b/scripts/check-continuation-memory.ts
@@ -1,0 +1,62 @@
+/**
+ * Verify that a 10x increase in lazily-produced continuation fragments stays
+ * within a fixed 128 MiB V8 old-space limit without retaining the input.
+ */
+import { spawnSync } from "node:child_process";
+
+interface MemoryResult {
+  fragments: number;
+  pages: number;
+  baselineHeap: number;
+  peakHeap: number;
+  retainedHeap: number;
+  outputBytes: number;
+  millis: number;
+}
+
+const small = runWorker(100);
+const large = runWorker(1000);
+const peakGrowth = large.peakHeap - small.peakHeap;
+const retainedGrowth = large.retainedHeap - small.retainedHeap;
+
+if (large.pages < small.pages * 8) {
+  throw new Error(`page count did not scale with input (${small.pages} to ${large.pages})`);
+}
+if (retainedGrowth > 16 * 1024 * 1024) {
+  throw new Error(`retained heap grew by ${formatBytes(retainedGrowth)} for a 10x workload`);
+}
+
+console.log(
+  `continuation memory: ${small.fragments} fragments/${small.pages} pages -> ` +
+  `${large.fragments} fragments/${large.pages} pages, peak heap ` +
+  `${formatBytes(small.peakHeap)} -> ${formatBytes(large.peakHeap)}, ` +
+  `retained heap ${formatBytes(small.retainedHeap)} -> ${formatBytes(large.retainedHeap)}, ` +
+  `peak growth ${formatBytes(peakGrowth)}, retained growth ${formatBytes(retainedGrowth)}`
+);
+
+/** Run one measurement in a fresh, heap-capped subprocess. */
+function runWorker(fragments: number): MemoryResult {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--expose-gc",
+      "--max-old-space-size=128",
+      "--import",
+      "tsx",
+      "scripts/continuation-memory-worker.ts",
+      String(fragments)
+    ],
+    { encoding: "utf8", maxBuffer: 1024 * 1024 }
+  );
+  if (child.status !== 0) {
+    throw new Error(`continuation memory worker failed: ${child.stderr || `exit ${child.status}`}`);
+  }
+  const line = child.stdout.trim().split("\n").at(-1);
+  if (!line) throw new Error("continuation memory worker returned no result");
+  return JSON.parse(line) as MemoryResult;
+}
+
+/** Format a byte count for stable human-readable benchmark output. */
+function formatBytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}

--- a/scripts/check-stream-visuals.ts
+++ b/scripts/check-stream-visuals.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { PDFDocument, StandardFonts } from "pdf-lib";
 import {
   PageSizes,
@@ -169,8 +169,10 @@ const scenarios: Scenario[] = [
           columns: [{ width: "1fr" }, { width: 48 }],
           header: [text("Item", { font: bold, size: 9 }), text("Qty", { font: bold, size: 9 })],
           rows: tableRows,
+          footer: [text("Total", { font: bold, size: 9 }), text("24", { font: bold, size: 9, align: "right" })],
           rowDivider: { color: hex("#cccccc"), thickness: 1 },
           headerDivider: { color: hex("#222222"), thickness: 1 },
+          footerDivider: { color: hex("#222222"), thickness: 1 },
           columnGap: 0
         });
       const chunkCount = Math.ceil(rows.length / 4);
@@ -212,6 +214,7 @@ const scenarios: Scenario[] = [
   }
 ];
 
+/** Render every parity scenario through both pagination paths. */
 async function main(): Promise<void> {
   const root = mkdtempSync(join(tmpdir(), "boxpdf-stream-visual-"));
   try {
@@ -256,22 +259,27 @@ async function main(): Promise<void> {
   }
 }
 
+/** Rasterize every PDF page and return paths in numeric page order. */
 function rasterize(pdf: string, prefix: string): string[] {
   execFileSync("pdftoppm", ["-png", "-r", "144", pdf, prefix], { stdio: "pipe" });
-  const directory = join(prefix, "..");
-  const stem = prefix.slice(prefix.lastIndexOf("/") + 1);
-  return readdirSync(directory)
+  const directory = dirname(prefix);
+  const stem = basename(prefix);
+  const pages = readdirSync(directory)
     .filter((name) => name.startsWith(`${stem}-`) && name.endsWith(".png"))
     .sort((left, right) => pageNumber(left) - pageNumber(right))
     .map((name) => join(directory, name));
+  if (pages.length === 0) throw new Error(`no rasterized pages for ${pdf}`);
+  return pages;
 }
 
+/** Extract the numeric page suffix emitted by pdftoppm. */
 function pageNumber(name: string): number {
   const match = name.match(/-(\d+)\.png$/);
   if (!match) throw new Error(`unexpected raster filename: ${name}`);
   return Number(match[1]);
 }
 
+/** Concatenate streamed PDF byte chunks for validation. */
 function concat(chunks: Uint8Array[]): Uint8Array {
   const output = new Uint8Array(chunks.reduce((sum, chunk) => sum + chunk.length, 0));
   let offset = 0;

--- a/scripts/check-stream-visuals.ts
+++ b/scripts/check-stream-visuals.ts
@@ -154,6 +154,40 @@ const scenarios: Scenario[] = [
     }
   },
   {
+    name: "continued-table",
+    async build(mode) {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+      const rows = Array.from({ length: 24 }, (_, index) => [
+        vstack({ padding: { top: 4, bottom: 4 } }, text(`Chunked row ${index + 1}`, { font, size: 9 })),
+        text(String(index + 1), { font, size: 9, align: "right" })
+      ]);
+      const makeTable = (tableRows: Node[][]) =>
+        table({
+          width: 220,
+          columns: [{ width: "1fr" }, { width: 48 }],
+          header: [text("Item", { font: bold, size: 9 }), text("Qty", { font: bold, size: 9 })],
+          rows: tableRows,
+          rowDivider: { color: hex("#cccccc"), thickness: 1 },
+          headerDivider: { color: hex("#222222"), thickness: 1 },
+          columnGap: 0
+        });
+      const chunkCount = Math.ceil(rows.length / 4);
+      const nodes =
+        mode === "buffered"
+          ? [makeTable(rows)]
+          : Array.from({ length: chunkCount }, (_, index) =>
+              flowContinuation(
+                makeTable(rows.slice(index * 4, index * 4 + 4)),
+                "continued-table",
+                index === chunkCount - 1
+              )
+            );
+      return { pdf, nodes, options: { size: { width: 260, height: 240 }, margin: 20 } };
+    }
+  },
+  {
     name: "fragmented-table",
     async build() {
       const pdf = await PDFDocument.create({ updateMetadata: false });

--- a/scripts/check-stream-visuals.ts
+++ b/scripts/check-stream-visuals.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { PDFDocument, StandardFonts } from "pdf-lib";
 import {
   PageSizes,
+  flowContinuation,
   hline,
   hstack,
   hex,
@@ -27,10 +28,60 @@ import {
 
 interface Scenario {
   name: string;
-  build(): Promise<{ pdf: PDFDocument; nodes: Node[]; options: StreamFlowOptions }>;
+  build(mode: "buffered" | "streamed"): Promise<{ pdf: PDFDocument; nodes: Node[]; options: StreamFlowOptions }>;
 }
 
 const scenarios: Scenario[] = [
+  {
+    name: "continued-stack",
+    async build(mode) {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const children = Array.from({ length: 16 }, (_, index) =>
+        vstack(
+          { height: 38, padding: 4, background: index % 2 === 0 ? hex("#edf2f7") : hex("#ffffff") },
+          text(`Continued child ${index + 1}`, { font, size: 9 })
+        )
+      );
+      const style = { gap: 5, padding: 7, border: { width: 1, color: hex("#334455") } };
+      const nodes =
+        mode === "buffered"
+          ? [vstack(style, ...children)]
+          : children.map((child, index) =>
+              flowContinuation(vstack(style, child), "continued-stack", index === children.length - 1)
+            );
+      return { pdf, nodes, options: { size: { width: 280, height: 250 }, margin: 20 } };
+    }
+  },
+  {
+    name: "nested-continuations",
+    async build(mode) {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const children = Array.from({ length: 16 }, (_, index) =>
+        vstack(
+          { height: 38, padding: 4, background: index % 2 === 0 ? hex("#edf2f7") : hex("#ffffff") },
+          text(`Continued child ${index + 1}`, { font, size: 9 })
+        )
+      );
+      const outerStyle = { gap: 5, padding: 7, border: { width: 1, color: hex("#334455") } };
+      const innerStyle = { gap: 3, padding: 5, border: { width: 1, color: hex("#99aabb") } };
+      const nodes =
+        mode === "buffered"
+          ? [vstack(outerStyle, vstack(innerStyle, ...children))]
+          : children.map((child, index) =>
+              flowContinuation(
+                vstack(
+                  outerStyle,
+                  flowContinuation(vstack(innerStyle, child), "inner", index === children.length - 1)
+                ),
+                "outer",
+                index === children.length - 1
+              )
+            );
+      return { pdf, nodes, options: { size: { width: 280, height: 250 }, margin: 20 } };
+    }
+  },
   {
     name: "multi-page-flow",
     async build() {
@@ -134,12 +185,12 @@ async function main(): Promise<void> {
       const scenarioDir = join(root, scenario.name);
       mkdirSync(scenarioDir, { recursive: true });
 
-      const buffered = await scenario.build();
+      const buffered = await scenario.build("buffered");
       await renderFlow(buffered.pdf, buffered.nodes, buffered.options);
       const bufferedPdf = join(scenarioDir, "render-flow.pdf");
       writeFileSync(bufferedPdf, await buffered.pdf.save());
 
-      const streamed = await scenario.build();
+      const streamed = await scenario.build("streamed");
       const chunks: Uint8Array[] = [];
       const writable = new WritableStream<Uint8Array>({
         write(chunk) {

--- a/scripts/check-stream-visuals.ts
+++ b/scripts/check-stream-visuals.ts
@@ -14,10 +14,13 @@ import {
   PageSizes,
   hline,
   hstack,
+  hex,
   pageInner,
   renderFlow,
   streamFlow,
+  table,
   text,
+  vstack,
   type Node,
   type StreamFlowOptions
 } from "../src/index.js";
@@ -78,6 +81,48 @@ const scenarios: Scenario[] = [
         footer: ({ pageNumber }) => text(`Page ${pageNumber}`, { font, size: 8, width, align: "right" })
       };
       return { pdf, nodes, options };
+    }
+  },
+  {
+    name: "fragmented-stack",
+    async build() {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const nodes = [
+        vstack(
+          { gap: 4, padding: 6, border: { width: 1, color: hex("#444444") } },
+          ...Array.from({ length: 14 }, (_, index) =>
+            vstack(
+              { height: 42, padding: 5, background: index % 2 === 0 ? hex("#eeeeee") : hex("#ffffff") },
+              text(`Fragment ${index + 1}`, { font, size: 10 })
+            )
+          )
+        )
+      ];
+      return { pdf, nodes, options: { size: { width: 260, height: 240 }, margin: 20 } };
+    }
+  },
+  {
+    name: "fragmented-table",
+    async build() {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+      const nodes = [
+        table({
+          width: 220,
+          columns: [{ width: "1fr" }, { width: 48 }],
+          header: [text("Item", { font: bold, size: 10 }), text("Qty", { font: bold, size: 10 })],
+          rows: Array.from({ length: 18 }, (_, index) => [
+            vstack({ padding: { top: 5, bottom: 5 } }, text(`Row ${index + 1}`, { font, size: 10 })),
+            text(String(index + 1), { font, size: 10, align: "right" })
+          ]),
+          rowDivider: { color: hex("#cccccc"), thickness: 1 },
+          headerDivider: { color: hex("#222222"), thickness: 1 },
+          columnGap: 0
+        })
+      ];
+      return { pdf, nodes, options: { size: { width: 260, height: 240 }, margin: 20 } };
     }
   }
 ];

--- a/scripts/check-stream-visuals.ts
+++ b/scripts/check-stream-visuals.ts
@@ -1,0 +1,158 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PDFDocument, StandardFonts } from "pdf-lib";
+import {
+  PageSizes,
+  hline,
+  hstack,
+  pageInner,
+  renderFlow,
+  streamFlow,
+  text,
+  type Node,
+  type StreamFlowOptions
+} from "../src/index.js";
+
+interface Scenario {
+  name: string;
+  build(): Promise<{ pdf: PDFDocument; nodes: Node[]; options: StreamFlowOptions }>;
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: "multi-page-flow",
+    async build() {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+      const width = pageInner(PageSizes.Letter, 36);
+      const nodes: Node[] = [];
+      for (let section = 1; section <= 8; section += 1) {
+        nodes.push(text(`Section ${section}`, { font: bold, size: 16, width }));
+        nodes.push(hline({ margin: { top: 3, bottom: 7 }, color: { r: 0.7, g: 0.7, b: 0.7 } }));
+        for (let line = 1; line <= 24; line += 1) {
+          nodes.push(
+            text(`Line ${line} in section ${section}. Streaming and buffered rendering must place this identically.`, {
+              font,
+              size: 10,
+              width,
+              margin: { top: 1, bottom: 1 }
+            })
+          );
+        }
+      }
+      return { pdf, nodes, options: { size: PageSizes.Letter, margin: 36 } };
+    }
+  },
+  {
+    name: "header-footer",
+    async build() {
+      const pdf = await PDFDocument.create({ updateMetadata: false });
+      const font = await pdf.embedFont(StandardFonts.Helvetica);
+      const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+      const width = pageInner(PageSizes.A4, 42);
+      const nodes = Array.from({ length: 120 }, (_, index) =>
+        hstack(
+          { width, gap: 12, margin: { top: 2, bottom: 2 } },
+          text(`#${String(index + 1).padStart(3, "0")}`, { font: bold, size: 10, width: 45 }),
+          text("A row with enough text to exercise width measurement and baseline placement.", {
+            font,
+            size: 10,
+            shrink: 1
+          })
+        )
+      );
+      const options: StreamFlowOptions = {
+        size: PageSizes.A4,
+        margin: 42,
+        header: ({ pageNumber }) => text(`Visual parity report · ${pageNumber}`, { font: bold, size: 9, width }),
+        footer: ({ pageNumber }) => text(`Page ${pageNumber}`, { font, size: 8, width, align: "right" })
+      };
+      return { pdf, nodes, options };
+    }
+  }
+];
+
+async function main(): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), "boxpdf-stream-visual-"));
+  try {
+    for (const scenario of scenarios) {
+      const scenarioDir = join(root, scenario.name);
+      mkdirSync(scenarioDir, { recursive: true });
+
+      const buffered = await scenario.build();
+      await renderFlow(buffered.pdf, buffered.nodes, buffered.options);
+      const bufferedPdf = join(scenarioDir, "render-flow.pdf");
+      writeFileSync(bufferedPdf, await buffered.pdf.save());
+
+      const streamed = await scenario.build();
+      const chunks: Uint8Array[] = [];
+      const writable = new WritableStream<Uint8Array>({
+        write(chunk) {
+          chunks.push(chunk);
+        }
+      });
+      await streamFlow(streamed.pdf, writable, streamed.nodes, streamed.options);
+      const streamedPdf = join(scenarioDir, "stream-flow.pdf");
+      writeFileSync(streamedPdf, concat(chunks));
+
+      const bufferedPages = rasterize(bufferedPdf, join(scenarioDir, "render"));
+      const streamedPages = rasterize(streamedPdf, join(scenarioDir, "stream"));
+      if (bufferedPages.length !== streamedPages.length) {
+        throw new Error(
+          `${scenario.name}: page count differs (${bufferedPages.length} buffered, ${streamedPages.length} streamed)`
+        );
+      }
+      for (let index = 0; index < bufferedPages.length; index += 1) {
+        const expected = readFileSync(bufferedPages[index]!);
+        const actual = readFileSync(streamedPages[index]!);
+        if (!expected.equals(actual)) {
+          throw new Error(`${scenario.name}: page ${index + 1} differs`);
+        }
+      }
+      console.log(`${scenario.name}: ${bufferedPages.length} page(s) match`);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function rasterize(pdf: string, prefix: string): string[] {
+  execFileSync("pdftoppm", ["-png", "-r", "144", pdf, prefix], { stdio: "pipe" });
+  const directory = join(prefix, "..");
+  const stem = prefix.slice(prefix.lastIndexOf("/") + 1);
+  return readdirSync(directory)
+    .filter((name) => name.startsWith(`${stem}-`) && name.endsWith(".png"))
+    .sort((left, right) => pageNumber(left) - pageNumber(right))
+    .map((name) => join(directory, name));
+}
+
+function pageNumber(name: string): number {
+  const match = name.match(/-(\d+)\.png$/);
+  if (!match) throw new Error(`unexpected raster filename: ${name}`);
+  return Number(match[1]);
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(chunks.reduce((sum, chunk) => sum + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/continuation-memory-worker.ts
+++ b/scripts/continuation-memory-worker.ts
@@ -1,0 +1,87 @@
+/**
+ * Isolated worker for the continuation memory check. It constructs each
+ * fragment only when the async iterable is advanced and reports peak heap.
+ */
+import { PDFDocument, StandardFonts, type PDFFont } from "pdf-lib";
+import {
+  PageSizes,
+  flowContinuation,
+  pageInner,
+  streamFlow,
+  text,
+  vstack,
+  type Node
+} from "../src/index.js";
+
+const fragmentCount = Number(process.argv[2]);
+if (!Number.isInteger(fragmentCount) || fragmentCount <= 0) {
+  throw new Error("usage: continuation-memory-worker.ts <positive-fragment-count>");
+}
+
+const pdf = await PDFDocument.create({ updateMetadata: false });
+const font = await pdf.embedFont(StandardFonts.Helvetica);
+const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+global.gc?.();
+
+const baselineHeap = process.memoryUsage().heapUsed;
+let peakHeap = baselineHeap;
+let outputBytes = 0;
+const sample = (): void => {
+  peakHeap = Math.max(peakHeap, process.memoryUsage().heapUsed);
+};
+const timer = setInterval(sample, 1);
+const startedAt = performance.now();
+
+try {
+  const result = await streamFlow(
+    pdf,
+    new WritableStream<Uint8Array>({
+      write(chunk) {
+        outputBytes += chunk.byteLength;
+        sample();
+      }
+    }),
+    fragments(fragmentCount, font, bold),
+    { size: PageSizes.Letter, margin: 36 }
+  );
+  sample();
+  global.gc?.();
+  console.log(JSON.stringify({
+    fragments: fragmentCount,
+    pages: result.pageCount,
+    baselineHeap,
+    peakHeap,
+    retainedHeap: process.memoryUsage().heapUsed,
+    outputBytes,
+    millis: Math.round(performance.now() - startedAt)
+  }));
+} finally {
+  clearInterval(timer);
+}
+
+/** Generate one page-scale continuation fragment at a time. */
+async function* fragments(
+  count: number,
+  bodyFont: PDFFont,
+  headingFont: PDFFont
+): AsyncIterable<Node> {
+  const width = pageInner(PageSizes.Letter, 36);
+  for (let fragment = 0; fragment < count; fragment += 1) {
+    const children: Node[] = [
+      text(`Section ${fragment + 1}`, { size: 16, font: headingFont, width })
+    ];
+    for (let line = 0; line < 50; line += 1) {
+      children.push(
+        text(
+          `Line ${line.toString().padStart(2, "0")}: bounded continuation content for section ${fragment + 1}.`,
+          { size: 10, font: bodyFont, width, margin: { top: 1, bottom: 1 } }
+        )
+      );
+    }
+    yield flowContinuation(
+      vstack({}, ...children),
+      "memory-benchmark",
+      fragment === count - 1
+    );
+  }
+}

--- a/src/document.ts
+++ b/src/document.ts
@@ -1,7 +1,7 @@
 import { PDFDocument, type PDFPage, type SaveOptions } from "pdf-lib";
 import { createMeasureCache, measure, withMeasureProfile, type MeasureProfileEvent } from "./measure.js";
 import { render, type RenderOptions } from "./render.js";
-import { edges, type EdgesInput, type Node } from "./types.js";
+import { edges, type EdgesInput, type Node, type TableFragmentationMeta } from "./types.js";
 import { savePdf } from "./save.js";
 import type { PdfEncryptionOptions } from "./encryption/types.js";
 
@@ -178,7 +178,7 @@ function splitTableStack(
   contentWidth: number
 ): { before: Node; after?: Node } | undefined {
   const meta = node.fragmentation;
-  const tableMeta =
+  const tableMeta: TableFragmentationMeta | undefined =
     meta?.kind === "table"
       ? meta
       : meta?.kind === "continuation"
@@ -209,6 +209,7 @@ function splitTableStack(
   return { before, after };
 }
 
+/** Split a fragmentable stack so its leading portion fits the current page. */
 export function splitForPage(
   node: Node,
   availableHeight: number,

--- a/src/document.ts
+++ b/src/document.ts
@@ -178,11 +178,17 @@ function splitTableStack(
   contentWidth: number
 ): { before: Node; after?: Node } | undefined {
   const meta = node.fragmentation;
-  if (meta?.kind !== "table") return undefined;
-  const header = node.children.slice(0, meta.headerCount);
-  const footerStart = node.children.length - meta.footerCount;
-  const footer = meta.footerCount > 0 ? node.children.slice(footerStart) : [];
-  const body = node.children.slice(meta.headerCount, footerStart);
+  const tableMeta =
+    meta?.kind === "table"
+      ? meta
+      : meta?.kind === "continuation"
+        ? meta.table
+        : undefined;
+  if (!tableMeta) return undefined;
+  const header = node.children.slice(0, tableMeta.headerCount);
+  const footerStart = node.children.length - tableMeta.footerCount;
+  const footer = tableMeta.footerCount > 0 ? node.children.slice(footerStart) : [];
+  const body = node.children.slice(tableMeta.headerCount, footerStart);
   if (body.length <= 1) return undefined;
 
   let splitAt = 0;
@@ -209,7 +215,10 @@ export function splitForPage(
   contentWidth: number
 ): { before: Node; after?: Node } | undefined {
   if (!isFragmentableStack(node)) return undefined;
-  if (node.fragmentation?.kind === "table") {
+  if (
+    node.fragmentation?.kind === "table" ||
+    (node.fragmentation?.kind === "continuation" && node.fragmentation.table)
+  ) {
     return splitTableStack(node, availableHeight, contentWidth);
   }
   return splitNormalStack(node, availableHeight, contentWidth);

--- a/src/document.ts
+++ b/src/document.ts
@@ -203,7 +203,7 @@ function splitTableStack(
   return { before, after };
 }
 
-function splitForPage(
+export function splitForPage(
   node: Node,
   availableHeight: number,
   contentWidth: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   aspectRatio,
   flex,
   group,
+  flowContinuation,
   hline,
   hstack,
   image,

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -37,6 +37,18 @@ export function group(...children: Node[]): Node {
 }
 
 /**
+ * Mark a bounded vstack fragment as part of one logical streamed stack.
+ * Consecutive fragments with the same id retain the same gap and box
+ * decoration semantics as a single vstack containing all children.
+ */
+export function flowContinuation(node: Node, id: string, final = false): Node {
+  if (node.kind !== "vstack") {
+    throw new Error("flowContinuation requires a vstack node");
+  }
+  return { ...node, fragmentation: { kind: "continuation", id, final } };
+}
+
+/**
  * Wraps children so that, under `renderFlow`, they paginate as one atomic
  * unit — if the combined height won't fit on the current page, the whole
  * group is pushed to the next page intact. Use it to keep

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -6,6 +6,7 @@ import type {
   Justify,
   Node,
   RGB,
+  TableFragmentationMeta,
   TextProps
 } from "./types.js";
 import type { InlineNodeRun, ParagraphItem, ParagraphProps, ParagraphRun, TextRunStyle } from "./paragraph.js";
@@ -45,7 +46,7 @@ export function flowContinuation(node: Node, id: string, final = false): Node {
   if (node.kind !== "vstack") {
     throw new Error("flowContinuation requires a vstack node");
   }
-  const table =
+  const table: TableFragmentationMeta | undefined =
     node.fragmentation?.kind === "table"
       ? {
           headerCount: node.fragmentation.headerCount,

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -45,7 +45,15 @@ export function flowContinuation(node: Node, id: string, final = false): Node {
   if (node.kind !== "vstack") {
     throw new Error("flowContinuation requires a vstack node");
   }
-  return { ...node, fragmentation: { kind: "continuation", id, final } };
+  const table =
+    node.fragmentation?.kind === "table"
+      ? {
+          headerCount: node.fragmentation.headerCount,
+          footerCount: node.fragmentation.footerCount,
+          rowDivider: node.fragmentation.rowDivider
+        }
+      : undefined;
+  return { ...node, fragmentation: { kind: "continuation", id, final, table } };
 }
 
 /**

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -556,6 +556,27 @@ function mergeContinuations(
     throw new Error("[boxpdf streamFlow] cannot merge unrelated continuations");
   }
   const children = [...left.children];
+  if (left.fragmentation.table && right.fragmentation.table) {
+    const rightHeaderCount = right.fragmentation.table.headerCount;
+    if (
+      left.fragmentation.table.rowDivider &&
+      left.children.length > left.fragmentation.table.headerCount &&
+      right.children.length > rightHeaderCount
+    ) {
+      children.push(left.fragmentation.table.rowDivider);
+    }
+    children.push(...right.children.slice(rightHeaderCount));
+    return {
+      ...left,
+      children,
+      fragmentation: {
+        kind: "continuation",
+        id: left.fragmentation.id,
+        final: right.fragmentation.final,
+        table: left.fragmentation.table
+      }
+    };
+  }
   const first = right.children[0];
   const last = children[children.length - 1];
   if (last && first && isContinuation(last) && isContinuation(first) && last.fragmentation.id === first.fragmentation.id) {
@@ -570,7 +591,8 @@ function mergeContinuations(
     fragmentation: {
       kind: "continuation",
       id: left.fragmentation.id,
-      final: right.fragmentation.final
+      final: right.fragmentation.final,
+      table: left.fragmentation.table
     }
   };
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,6 +28,7 @@ import { render } from "./render.js";
 import { edges, type EdgesInput, type Node } from "./types.js";
 import {
   PageSizes,
+  splitForPage,
   type PageSize,
   type DocumentMetadata
 } from "./document.js";
@@ -333,27 +334,64 @@ export async function streamFlow(
       currentPage = undefined;
     };
 
-    for await (const node of nodes) {
-      checkMidStreamEmbed();
+    for await (const input of nodes) {
+      const pending = [input];
+      while (pending.length > 0) {
+        checkMidStreamEmbed();
+        const node = pending.shift()!;
+        const nodeSize = measure(node, contentWidth);
+        if (warnings && nodeSize.width > contentWidth + 0.5) {
+          console.warn(
+            `[boxpdf] top-level ${node.kind} measured ${nodeSize.width.toFixed(1)}pt — ` +
+              `exceeds page content area ${contentWidth.toFixed(1)}pt`
+          );
+        }
 
-      const nodeSize = measure(node, contentWidth);
-      if (warnings && nodeSize.width > contentWidth + 0.5) {
-        console.warn(
-          `[boxpdf] top-level ${node.kind} measured ${nodeSize.width.toFixed(1)}pt — ` +
-            `exceeds page content area ${contentWidth.toFixed(1)}pt`
-        );
+        if (!currentPage) startPage();
+        const remainingHeight = cursorY - contentBottom;
+        if (nodeSize.height > remainingHeight) {
+          const split = splitForPage(node, remainingHeight, contentWidth);
+          if (split && cursorY !== contentTop) {
+            const beforeSize = measure(split.before, contentWidth);
+            render(split.before, currentPage!, m.left, cursorY, contentWidth, {
+              debug: options.debug
+            });
+            cursorY -= beforeSize.height;
+            await closePage();
+            startPage();
+            if (split.after) pending.unshift(split.after);
+            continue;
+          }
+        }
+
+        if (cursorY - nodeSize.height < contentBottom && cursorY !== contentTop) {
+          await closePage();
+          startPage();
+          pending.unshift(node);
+          continue;
+        }
+
+        const topRemainingHeight = cursorY - contentBottom;
+        if (nodeSize.height > topRemainingHeight) {
+          const split = splitForPage(node, topRemainingHeight, contentWidth);
+          if (split) {
+            const beforeSize = measure(split.before, contentWidth);
+            render(split.before, currentPage!, m.left, cursorY, contentWidth, {
+              debug: options.debug
+            });
+            cursorY -= beforeSize.height;
+            await closePage();
+            startPage();
+            if (split.after) pending.unshift(split.after);
+            continue;
+          }
+        }
+
+        render(node, currentPage!, m.left, cursorY, contentWidth, {
+          debug: options.debug
+        });
+        cursorY -= nodeSize.height;
       }
-
-      if (!currentPage) startPage();
-      else if (cursorY - nodeSize.height < contentBottom) {
-        await closePage();
-        startPage();
-      }
-
-      render(node, currentPage!, m.left, cursorY, contentWidth, {
-        debug: options.debug
-      });
-      cursorY -= nodeSize.height;
     }
 
     if (currentPage) await closePage();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -36,6 +36,10 @@ import type { PdfEncryptionOptions } from "./encryption/types.js";
 import type { EncryptionContext } from "./encryption/serialize.js";
 import type { PreparedEncryption } from "./encryption/writer.js";
 
+type ContinuationNode = Extract<Node, { kind: "vstack" }> & {
+  fragmentation: { kind: "continuation"; id: string; final: boolean };
+};
+
 export interface StreamPageContext {
   /** Current page number, 1-indexed. */
   pageNumber: number;
@@ -334,8 +338,7 @@ export async function streamFlow(
       currentPage = undefined;
     };
 
-    for await (const input of nodes) {
-      const pending = [input];
+    const processNodes = async (pending: Node[]): Promise<void> => {
       while (pending.length > 0) {
         checkMidStreamEmbed();
         const node = pending.shift()!;
@@ -392,6 +395,70 @@ export async function streamFlow(
         });
         cursorY -= nodeSize.height;
       }
+    };
+
+    const flushContinuationPages = async (
+      initial: ContinuationNode
+    ): Promise<ContinuationNode> => {
+      let node = initial;
+      while (true) {
+        if (!currentPage) startPage();
+        const remainingHeight = cursorY - contentBottom;
+        if (measure(node, contentWidth).height <= remainingHeight) return node;
+        const split = splitForPage(node, remainingHeight, contentWidth);
+        if (!split) {
+          if (cursorY !== contentTop) {
+            await closePage();
+            startPage();
+            continue;
+          }
+          return node;
+        }
+        const beforeSize = measure(split.before, contentWidth);
+        render(split.before, currentPage!, m.left, cursorY, contentWidth, {
+          debug: options.debug
+        });
+        cursorY -= beforeSize.height;
+        await closePage();
+        startPage();
+        if (!split.after || !isContinuation(split.after)) {
+          throw new Error("[boxpdf streamFlow] invalid continuation split");
+        }
+        node = split.after;
+      }
+    };
+
+    let continuation: ContinuationNode | undefined;
+    for await (const input of nodes) {
+      if (isContinuation(input)) {
+        if (continuation && continuation.fragmentation?.id !== input.fragmentation.id) {
+          throw new Error(
+            `[boxpdf streamFlow] continuation "${continuation.fragmentation?.id}" ` +
+              `was interrupted by "${input.fragmentation.id}"`
+          );
+        }
+        continuation = continuation ? mergeContinuations(continuation, input) : input;
+        if (input.fragmentation.final) {
+          await processNodes([continuation]);
+          continuation = undefined;
+        } else {
+          continuation = await flushContinuationPages(continuation);
+        }
+        continue;
+      }
+      if (continuation) {
+        throw new Error(
+          `[boxpdf streamFlow] continuation "${continuation.fragmentation?.id}" ` +
+            "ended without a final fragment"
+        );
+      }
+      await processNodes([input]);
+    }
+    if (continuation) {
+      throw new Error(
+        `[boxpdf streamFlow] continuation "${continuation.fragmentation?.id}" ` +
+          "ended without a final fragment"
+      );
     }
 
     if (currentPage) await closePage();
@@ -473,6 +540,39 @@ export async function streamFlow(
       }
     }
   }
+}
+
+function isContinuation(
+  node: Node
+): node is ContinuationNode {
+  return node.kind === "vstack" && node.fragmentation?.kind === "continuation";
+}
+
+function mergeContinuations(
+  left: ContinuationNode,
+  right: ContinuationNode
+): ContinuationNode {
+  if (!isContinuation(left) || !isContinuation(right) || left.fragmentation.id !== right.fragmentation.id) {
+    throw new Error("[boxpdf streamFlow] cannot merge unrelated continuations");
+  }
+  const children = [...left.children];
+  const first = right.children[0];
+  const last = children[children.length - 1];
+  if (last && first && isContinuation(last) && isContinuation(first) && last.fragmentation.id === first.fragmentation.id) {
+    children[children.length - 1] = mergeContinuations(last, first);
+    children.push(...right.children.slice(1));
+  } else {
+    children.push(...right.children);
+  }
+  return {
+    ...left,
+    children,
+    fragmentation: {
+      kind: "continuation",
+      id: left.fragmentation.id,
+      final: right.fragmentation.final
+    }
+  };
 }
 
 /**

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -25,7 +25,7 @@ import {
 } from "pdf-lib";
 import { measure } from "./measure.js";
 import { render } from "./render.js";
-import { edges, type EdgesInput, type Node } from "./types.js";
+import { edges, type EdgesInput, type Fragmentation, type Node } from "./types.js";
 import {
   PageSizes,
   splitForPage,
@@ -37,7 +37,7 @@ import type { EncryptionContext } from "./encryption/serialize.js";
 import type { PreparedEncryption } from "./encryption/writer.js";
 
 type ContinuationNode = Extract<Node, { kind: "vstack" }> & {
-  fragmentation: { kind: "continuation"; id: string; final: boolean };
+  fragmentation: Extract<Fragmentation, { kind: "continuation" }>;
 };
 
 export interface StreamPageContext {
@@ -162,6 +162,8 @@ export async function streamFlow(
     const pdfInternals = pdf as unknown as {
       fonts?: { length: number }[];
       images?: { length: number }[];
+      pageMap?: Map<unknown, unknown>;
+      pageCache?: { invalidate(): void };
     };
     const initialFontCount = Array.isArray(pdfInternals.fonts) ? pdfInternals.fonts.length : 0;
     const initialImageCount = Array.isArray(pdfInternals.images) ? pdfInternals.images.length : 0;
@@ -335,10 +337,31 @@ export async function streamFlow(
         }
         await serializeRef(ref, obj);
       }
+      // pdf-lib caches every PDFPage wrapper in pageMap. Each wrapper retains
+      // its in-memory content stream even after the stream ref is deleted from
+      // the context, which otherwise adds roughly one rendered page of heap per
+      // output page. The page leaf remains in the page tree/context and can be
+      // wrapped again by getPages() after streaming.
+      pdfInternals.pageMap?.delete(currentPage.node);
+      pdfInternals.pageCache?.invalidate();
       currentPage = undefined;
     };
 
     const processNodes = async (pending: Node[]): Promise<void> => {
+      /** Render the fitting portion, flush its page, and queue any remainder. */
+      const renderSplitAndBreak = async (
+        split: { before: Node; after?: Node }
+      ): Promise<void> => {
+        const beforeSize = measure(split.before, contentWidth);
+        render(split.before, currentPage!, m.left, cursorY, contentWidth, {
+          debug: options.debug
+        });
+        cursorY -= beforeSize.height;
+        await closePage();
+        startPage();
+        if (split.after) pending.unshift(split.after);
+      };
+
       while (pending.length > 0) {
         checkMidStreamEmbed();
         const node = pending.shift()!;
@@ -355,14 +378,7 @@ export async function streamFlow(
         if (nodeSize.height > remainingHeight) {
           const split = splitForPage(node, remainingHeight, contentWidth);
           if (split && cursorY !== contentTop) {
-            const beforeSize = measure(split.before, contentWidth);
-            render(split.before, currentPage!, m.left, cursorY, contentWidth, {
-              debug: options.debug
-            });
-            cursorY -= beforeSize.height;
-            await closePage();
-            startPage();
-            if (split.after) pending.unshift(split.after);
+            await renderSplitAndBreak(split);
             continue;
           }
         }
@@ -378,14 +394,7 @@ export async function streamFlow(
         if (nodeSize.height > topRemainingHeight) {
           const split = splitForPage(node, topRemainingHeight, contentWidth);
           if (split) {
-            const beforeSize = measure(split.before, contentWidth);
-            render(split.before, currentPage!, m.left, cursorY, contentWidth, {
-              debug: options.debug
-            });
-            cursorY -= beforeSize.height;
-            await closePage();
-            startPage();
-            if (split.after) pending.unshift(split.after);
+            await renderSplitAndBreak(split);
             continue;
           }
         }
@@ -431,9 +440,9 @@ export async function streamFlow(
     let continuation: ContinuationNode | undefined;
     for await (const input of nodes) {
       if (isContinuation(input)) {
-        if (continuation && continuation.fragmentation?.id !== input.fragmentation.id) {
+        if (continuation && continuation.fragmentation.id !== input.fragmentation.id) {
           throw new Error(
-            `[boxpdf streamFlow] continuation "${continuation.fragmentation?.id}" ` +
+            `[boxpdf streamFlow] continuation "${continuation.fragmentation.id}" ` +
               `was interrupted by "${input.fragmentation.id}"`
           );
         }
@@ -448,15 +457,15 @@ export async function streamFlow(
       }
       if (continuation) {
         throw new Error(
-          `[boxpdf streamFlow] continuation "${continuation.fragmentation?.id}" ` +
-            "ended without a final fragment"
+          `[boxpdf streamFlow] continuation "${continuation.fragmentation.id}" ` +
+            `was interrupted by a non-continuation ${input.kind} node`
         );
       }
       await processNodes([input]);
     }
     if (continuation) {
       throw new Error(
-        `[boxpdf streamFlow] continuation "${continuation.fragmentation?.id}" ` +
+        `[boxpdf streamFlow] continuation "${continuation.fragmentation.id}" ` +
           "ended without a final fragment"
       );
     }
@@ -542,12 +551,14 @@ export async function streamFlow(
   }
 }
 
+/** Narrow a node to a bounded streamed continuation fragment. */
 function isContinuation(
   node: Node
 ): node is ContinuationNode {
   return node.kind === "vstack" && node.fragmentation?.kind === "continuation";
 }
 
+/** Merge two adjacent fragments while preserving stack and table semantics. */
 function mergeContinuations(
   left: ContinuationNode,
   right: ContinuationNode
@@ -555,17 +566,30 @@ function mergeContinuations(
   if (!isContinuation(left) || !isContinuation(right) || left.fragmentation.id !== right.fragmentation.id) {
     throw new Error("[boxpdf streamFlow] cannot merge unrelated continuations");
   }
-  const children = [...left.children];
   if (left.fragmentation.table && right.fragmentation.table) {
+    const leftTable = left.fragmentation.table;
+    const rightTable = right.fragmentation.table;
+    const leftFooterStart = left.children.length - leftTable.footerCount;
     const rightHeaderCount = right.fragmentation.table.headerCount;
+    const rightFooterStart = right.children.length - rightTable.footerCount;
+    const leftBody = left.children.slice(leftTable.headerCount, leftFooterStart);
+    const rightBody = right.children.slice(rightHeaderCount, rightFooterStart);
+    const children = [
+      ...left.children.slice(0, leftTable.headerCount),
+      ...leftBody
+    ];
     if (
-      left.fragmentation.table.rowDivider &&
-      left.children.length > left.fragmentation.table.headerCount &&
-      right.children.length > rightHeaderCount
+      leftTable.rowDivider &&
+      leftBody.length > 0 &&
+      rightBody.length > 0
     ) {
-      children.push(left.fragmentation.table.rowDivider);
+      children.push(leftTable.rowDivider);
     }
-    children.push(...right.children.slice(rightHeaderCount));
+    children.push(...rightBody);
+    const footerCount = right.fragmentation.final ? rightTable.footerCount : 0;
+    if (footerCount > 0) {
+      children.push(...right.children.slice(rightFooterStart));
+    }
     return {
       ...left,
       children,
@@ -573,10 +597,14 @@ function mergeContinuations(
         kind: "continuation",
         id: left.fragmentation.id,
         final: right.fragmentation.final,
-        table: left.fragmentation.table
+        table: {
+          ...leftTable,
+          footerCount
+        }
       }
     };
   }
+  const children = [...left.children];
   const first = right.children[0];
   const last = children[children.length - 1];
   if (last && first && isContinuation(last) && isContinuation(first) && last.fragmentation.id === first.fragmentation.id) {

--- a/src/table.ts
+++ b/src/table.ts
@@ -358,7 +358,12 @@ export function table(options: TableOptions): Node {
     ...children
   );
   if (node.kind === "vstack") {
-    node.fragmentation = { kind: "table", headerCount, footerCount };
+    node.fragmentation = {
+      kind: "table",
+      headerCount,
+      footerCount,
+      rowDivider: borderCollapse === "collapse" ? undefined : dividerNode(rowDivider)
+    };
   }
   return node;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,11 +36,21 @@ export type BoxTransform =
   | { kind: "skew"; xDegrees: number; yDegrees: number }
   | { kind: "matrix"; a: number; b: number; c: number; d: number; e: number; f: number };
 export type TransformOrigin = { x: RelativeLength; y: RelativeLength };
-export type Fragmentation = {
-  kind: "table";
-  headerCount: number;
-  footerCount: number;
-};
+export type Fragmentation =
+  | {
+      kind: "table";
+      headerCount: number;
+      footerCount: number;
+    }
+  | {
+      /**
+       * One bounded fragment of a logical vstack supplied incrementally.
+       * Consecutive fragments with the same id are merged before pagination.
+       */
+      kind: "continuation";
+      id: string;
+      final: boolean;
+    };
 
 export interface BoxStyle {
   /** Fixed width; if omitted, the box sizes to its content. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type Fragmentation =
       kind: "table";
       headerCount: number;
       footerCount: number;
+      rowDivider?: Node;
     }
   | {
       /**
@@ -50,6 +51,12 @@ export type Fragmentation =
       kind: "continuation";
       id: string;
       final: boolean;
+      /** Preserve table row fragmentation while table chunks are merged. */
+      table?: {
+        headerCount: number;
+        footerCount: number;
+        rowDivider?: Node;
+      };
     };
 
 export interface BoxStyle {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,13 +36,16 @@ export type BoxTransform =
   | { kind: "skew"; xDegrees: number; yDegrees: number }
   | { kind: "matrix"; a: number; b: number; c: number; d: number; e: number; f: number };
 export type TransformOrigin = { x: RelativeLength; y: RelativeLength };
+
+/** Table structure retained while a vstack is split across pages. */
+export interface TableFragmentationMeta {
+  headerCount: number;
+  footerCount: number;
+  rowDivider?: Node;
+}
+
 export type Fragmentation =
-  | {
-      kind: "table";
-      headerCount: number;
-      footerCount: number;
-      rowDivider?: Node;
-    }
+  | ({ kind: "table" } & TableFragmentationMeta)
   | {
       /**
        * One bounded fragment of a logical vstack supplied incrementally.
@@ -52,11 +55,7 @@ export type Fragmentation =
       id: string;
       final: boolean;
       /** Preserve table row fragmentation while table chunks are merged. */
-      table?: {
-        headerCount: number;
-        footerCount: number;
-        rowDivider?: Node;
-      };
+      table?: TableFragmentationMeta;
     };
 
 export interface BoxStyle {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -206,6 +206,33 @@ describe("streamFlow basics", () => {
       )
     ).rejects.toThrow(/without a final fragment/);
   });
+
+  it("merges table continuations while retaining row fragmentation", async () => {
+    const { pdf, font, bold } = await newDocWithFonts();
+    const makeChunk = (start: number, final: boolean) =>
+      flowContinuation(
+        table({
+          width: 180,
+          columns: [{ width: "1fr" }],
+          header: [text("Header", { font: bold, size: 10 })],
+          rows: Array.from({ length: 4 }, (_, index) => [
+            vstack({ height: 28 }, text(`Row ${start + index}`, { font, size: 9 }))
+          ])
+        }),
+        "table",
+        final
+      );
+    const { writable, bytes } = collector();
+    const { pageCount } = await streamFlow(
+      pdf,
+      writable,
+      [makeChunk(1, false), makeChunk(5, false), makeChunk(9, true)],
+      { size: { width: 220, height: 180 }, margin: 20 }
+    );
+
+    expect(pageCount).toBeGreaterThan(1);
+    expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
+  });
 });
 
 describe("streamFlow headers and footers", () => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -10,6 +10,7 @@ import {
   link,
   nodeAdapter,
   pageInner,
+  renderFlow,
   streamFlow,
   table,
   text,
@@ -173,25 +174,35 @@ describe("streamFlow basics", () => {
   });
 
   it("merges bounded continuation fragments before pagination", async () => {
-    const { pdf, font } = await newDocWithFonts();
+    const options = { size: { width: 240, height: 220 }, margin: 20 };
+    const buffered = await newDocWithFonts();
+    const bufferedChildren = Array.from({ length: 12 }, (_, index) =>
+      vstack({ height: 42 }, text(`Fragment ${index + 1}`, { font: buffered.font, size: 10 }))
+    );
+    const { pages } = await renderFlow(
+      buffered.pdf,
+      [vstack({ gap: 4, padding: 6, border: { width: 1, color: hex("#444444") } }, ...bufferedChildren)],
+      options
+    );
+
+    const streamed = await newDocWithFonts();
     const fragments = Array.from({ length: 12 }, (_, index) =>
       flowContinuation(
         vstack(
           { gap: 4, padding: 6, border: { width: 1, color: hex("#444444") } },
-          vstack({ height: 42 }, text(`Fragment ${index + 1}`, { font, size: 10 }))
+          vstack({ height: 42 }, text(`Fragment ${index + 1}`, { font: streamed.font, size: 10 }))
         ),
         "report",
         index === 11
       )
     );
     const { writable, bytes } = collector();
-    const { pageCount } = await streamFlow(pdf, writable, fragments, {
-      size: { width: 240, height: 220 },
-      margin: 20
-    });
+    const { pageCount } = await streamFlow(streamed.pdf, writable, fragments, options);
 
     expect(pageCount).toBeGreaterThan(1);
+    expect(pageCount).toBe(pages.length);
     expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
+    expect(streamed.pdf.getPages()).toHaveLength(pageCount);
   });
 
   it("rejects a continuation without a final fragment", async () => {
@@ -207,30 +218,66 @@ describe("streamFlow basics", () => {
     ).rejects.toThrow(/without a final fragment/);
   });
 
+  it("reports a plain-node interruption separately from end of stream", async () => {
+    const { pdf, font } = await newDocWithFonts();
+    const { writable } = collector();
+    await expect(
+      streamFlow(
+        pdf,
+        writable,
+        [
+          flowContinuation(vstack({}, text("unfinished", { font, size: 10 })), "unfinished"),
+          text("interrupting node", { font, size: 10 })
+        ],
+        { margin: 20 }
+      )
+    ).rejects.toThrow(/interrupted by a non-continuation text node/);
+  });
+
   it("merges table continuations while retaining row fragmentation", async () => {
-    const { pdf, font, bold } = await newDocWithFonts();
+    const options = { size: { width: 220, height: 180 }, margin: 20 };
+    const makeTable = (
+      tableFont: PDFFont,
+      tableBold: PDFFont,
+      start: number,
+      count: number
+    ) =>
+      table({
+        width: 180,
+        columns: [{ width: "1fr" }],
+        header: [text("Header", { font: tableBold, size: 10 })],
+        rows: Array.from({ length: count }, (_, index) => [
+          vstack({ height: 28 }, text(`Row ${start + index}`, { font: tableFont, size: 9 }))
+        ]),
+        footer: [text("Footer", { font: tableBold, size: 9 })],
+        rowDivider: { color: hex("#dddddd"), thickness: 1 },
+        footerDivider: { color: hex("#111111"), thickness: 1 }
+      });
+
+    const buffered = await newDocWithFonts();
+    const { pages } = await renderFlow(
+      buffered.pdf,
+      [makeTable(buffered.font, buffered.bold, 1, 12)],
+      options
+    );
+
+    const streamed = await newDocWithFonts();
     const makeChunk = (start: number, final: boolean) =>
       flowContinuation(
-        table({
-          width: 180,
-          columns: [{ width: "1fr" }],
-          header: [text("Header", { font: bold, size: 10 })],
-          rows: Array.from({ length: 4 }, (_, index) => [
-            vstack({ height: 28 }, text(`Row ${start + index}`, { font, size: 9 }))
-          ])
-        }),
+        makeTable(streamed.font, streamed.bold, start, 4),
         "table",
         final
       );
     const { writable, bytes } = collector();
     const { pageCount } = await streamFlow(
-      pdf,
+      streamed.pdf,
       writable,
       [makeChunk(1, false), makeChunk(5, false), makeChunk(9, true)],
-      { size: { width: 220, height: 180 }, margin: 20 }
+      options
     );
 
     expect(pageCount).toBeGreaterThan(1);
+    expect(pageCount).toBe(pages.length);
     expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
   });
 });

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -5,10 +5,12 @@ import {
   PageSizes,
   hline,
   hstack,
+  hex,
   link,
   nodeAdapter,
   pageInner,
   streamFlow,
+  table,
   text,
   vstack,
   type Node
@@ -119,6 +121,54 @@ describe("streamFlow basics", () => {
     });
     expect(pageCount).toBe(1);
     expect(bytes().byteLength).toBeGreaterThan(500);
+  });
+
+  it("fragments a top-level vstack between children", async () => {
+    const { pdf, font } = await newDocWithFonts();
+    const blocks = Array.from({ length: 6 }, (_, index) =>
+      vstack(
+        { height: 54, padding: 6, border: { color: hex("#dddddd"), width: 1 } },
+        text(`Fragment ${index + 1}`, { size: 10, font })
+      )
+    );
+    const { writable, bytes } = collector();
+    const { pageCount } = await streamFlow(pdf, writable, [vstack({ gap: 4 }, ...blocks)], {
+      size: { width: 240, height: 220 },
+      margin: 20
+    });
+
+    expect(pageCount).toBeGreaterThan(1);
+    expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
+  });
+
+  it("fragments tables between rows", async () => {
+    const { pdf, font, bold } = await newDocWithFonts();
+    const node = table({
+      width: 180,
+      columns: [{ width: "1fr" }, { width: 50 }],
+      header: [
+        text("Item", { size: 10, font: bold }),
+        text("Qty", { size: 10, font: bold })
+      ],
+      rows: Array.from({ length: 10 }, (_, index) => [
+        vstack(
+          { padding: { top: 5, bottom: 5 } },
+          text(`Row ${index + 1}`, { size: 10, font })
+        ),
+        text(String(index + 1), { size: 10, font })
+      ]),
+      rowDivider: { color: hex("#dddddd"), thickness: 1 },
+      headerDivider: { color: hex("#111111"), thickness: 1 },
+      columnGap: 0
+    });
+    const { writable, bytes } = collector();
+    const { pageCount } = await streamFlow(pdf, writable, [node], {
+      size: { width: 240, height: 220 },
+      margin: 20
+    });
+
+    expect(pageCount).toBeGreaterThan(1);
+    expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
   });
 });
 

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -3,6 +3,7 @@ import { PassThrough } from "node:stream";
 import { PDFDocument, StandardFonts, type PDFFont } from "pdf-lib";
 import {
   PageSizes,
+  flowContinuation,
   hline,
   hstack,
   hex,
@@ -169,6 +170,41 @@ describe("streamFlow basics", () => {
 
     expect(pageCount).toBeGreaterThan(1);
     expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
+  });
+
+  it("merges bounded continuation fragments before pagination", async () => {
+    const { pdf, font } = await newDocWithFonts();
+    const fragments = Array.from({ length: 12 }, (_, index) =>
+      flowContinuation(
+        vstack(
+          { gap: 4, padding: 6, border: { width: 1, color: hex("#444444") } },
+          vstack({ height: 42 }, text(`Fragment ${index + 1}`, { font, size: 10 }))
+        ),
+        "report",
+        index === 11
+      )
+    );
+    const { writable, bytes } = collector();
+    const { pageCount } = await streamFlow(pdf, writable, fragments, {
+      size: { width: 240, height: 220 },
+      margin: 20
+    });
+
+    expect(pageCount).toBeGreaterThan(1);
+    expect((await PDFDocument.load(bytes())).getPageCount()).toBe(pageCount);
+  });
+
+  it("rejects a continuation without a final fragment", async () => {
+    const { pdf, font } = await newDocWithFonts();
+    const { writable } = collector();
+    await expect(
+      streamFlow(
+        pdf,
+        writable,
+        [flowContinuation(vstack({}, text("unfinished", { font, size: 10 })), "unfinished")],
+        { margin: 20 }
+      )
+    ).rejects.toThrow(/without a final fragment/);
   });
 });
 


### PR DESCRIPTION
## Summary

- align `streamFlow` pagination with buffered `renderFlow`
- add bounded, consecutive `flowContinuation` fragments for stacks and tables
- preserve gaps, decoration, table headers, footers, and row dividers across fragment boundaries
- reject interrupted or unfinished continuation sequences
- release rendered page wrappers so continuation input and page content do not accumulate
- add all-page PDF-to-PNG parity checks and continuation-memory CI gates
- bump the package to 1.12.0

## Why

Large HTML documents need to release layout nodes incrementally without changing the PDF rendering contract. These continuation primitives let the HTML renderer bound its retained tree while producing the same pages as a buffered logical node.

## Published memory benchmark

The benchmark constructs continuation fragments lazily in fresh subprocesses capped with `--max-old-space-size=128`:

| Continuation fragments | Output pages | Sampled peak heap | Retained heap after GC | Output |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 81 | ~58 MB | ~16 MB | 129 KB |
| 1000 | 810 | ~125 MB | ~26 MB | 1.3 MB |

Retained heap grows by about 10 MB across the 10× workload. Reproduce it with `pnpm memory:check:continuation`; CI runs the same heap-capped check.

## Validation

- `pnpm run prepublishOnly` — 205 tests, typecheck, and build pass
- `pnpm run visual:check:stream` — every rendered page matches for 7 scenarios, including continued/nested stacks and continued tables with footers
- `pnpm run memory:check:continuation` — 100 → 1,000 lazy fragments complete within the 128 MiB old-space cap
- hosted GitHub Actions run is green

Companion PR: earonesty/boxpdf-html#11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `flowContinuation` to help render large stacks and tables across bounded streamed fragments.
  * Streamed pagination now merges and continues fragments correctly across page boundaries, including table header/footer behavior.
* **Bug Fixes**
  * Interrupted or incomplete continuation sequences are rejected instead of producing partial layouts.
* **Tests**
  * Added strict visual parity checks between streamed and buffered rendering.
  * Added continuation-specific memory verification.
* **Documentation**
  * Updated streaming output docs with `flowContinuation` sequencing rules and pagination semantics.
* **Chores**
  * Added CI workflow and bumped package version to 1.12.0; added related publish workflow credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->