### PR TITLE
Refresh public page for bounded streaming and encryption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Check public page
+        run: pnpm run docs:check
+
       - name: Check streamed visual parity
         run: pnpm run visual:check:stream
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Public page
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload public page
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+
+      - name: Deploy public page
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>boxpdf · open-source HTML and declarative PDF generation</title>
-<meta name="description" content="Open-source HTML-to-PDF and declarative PDF layout for JavaScript runtimes. Render Tailwind HTML or box-layout primitives without WASM, headless Chrome, or React." />
+<meta name="description" content="Open-source, bounded-memory HTML-to-PDF and declarative PDF layout for JavaScript runtimes, with streaming output and PDF 2.0 AES-256 encryption." />
 <link rel="icon" href="./boxpdf-mark.svg" type="image/svg+xml" />
 <link rel="apple-touch-icon" href="./boxpdf-mark.svg" />
 <link rel="stylesheet" href="./style.css" />
@@ -18,6 +18,7 @@
     <a href="#themes">Themes</a>
     <a href="#templates">Templates</a>
     <a href="#memory">Memory</a>
+    <a href="#security">Security</a>
     <a href="#install">Install</a>
     <a href="https://github.com/earonesty/boxpdf" target="_blank" rel="noopener">GitHub</a>
   </nav>
@@ -39,7 +40,8 @@
       <span>HTML + Tailwind input</span>
       <span>MIT open source</span>
       <span>Edge-ready PDFs</span>
-      <span>Streaming output</span>
+      <span>Bounded-memory streaming</span>
+      <span>PDF 2.0 AES-256</span>
     </div>
     <div class="cta-row">
       <a class="btn btn-primary" href="#install">Install</a>
@@ -83,7 +85,11 @@ const bytes = await pdf.save(); // -&gt; Uint8Array</code></pre>
       </div>
       <div class="feature">
         <h3>Streaming output</h3>
-        <p><code>streamFlow</code> emits bytes to a <code>WritableStream</code> as each page closes. Peak heap stays flat at any page count. A 1000-page report uses 5× less memory than <code>renderFlow + pdf.save()</code>.</p>
+        <p><code>streamFlow</code> emits bytes to a <code>WritableStream</code> as each page closes. In the 1000-page benchmark it used 25.4 MB peak heap versus 219.6 MB for <code>renderFlow + pdf.save()</code>.</p>
+      </div>
+      <div class="feature">
+        <h3>PDF 2.0 AES-256 encryption</h3>
+        <p>Password encryption happens during serialization—including streamed output—with optional owner credentials and viewer permissions. No temporary plaintext PDF or encryption post-process.</p>
       </div>
       <div class="feature">
         <h3>Four named themes</h3>
@@ -147,6 +153,32 @@ const bytes = await pdf.save(); // -&gt; Uint8Array</code></pre>
           <a class="source" href="https://github.com/earonesty/boxpdf/tree/main/html/fixtures" target="_blank" rel="noopener">html/fixtures</a>
         </figcaption>
       </figure>
+    </div>
+  </section>
+
+  <section id="large-documents" class="block spotlight">
+    <p class="eyebrow">New in boxpdf 1.12 + boxpdf-html 1.6</p>
+    <h2>Large HTML, without the large heap</h2>
+    <p class="block-lede">
+      The HTML CLI now makes two bounded passes: one to discover CSS, fonts, and images, then one to parse, lay out, and write the PDF incrementally. A single open wrapper can span every fragment, so large real-world documents do not need artificial page-sized roots.
+    </p>
+    <div class="showcase-grid">
+      <article class="showcase-card">
+        <h3>Stream from a file or stdin</h3>
+        <pre><code>npx boxpdf-html archive.html archive.pdf --stream
+
+cat archive.html | npx boxpdf-html - archive.pdf --stream</code></pre>
+        <p>The destination is replaced only after conversion succeeds. Stdin is spooled to a temporary file for the required second pass.</p>
+      </article>
+      <article class="showcase-card">
+        <h3>Measured with one continuous wrapper</h3>
+        <div class="stat-grid">
+          <div class="stat"><strong>10×</strong><span>HTML input growth<br />10 → 100 MiB</span></div>
+          <div class="stat"><strong>1.54×</strong><span>peak RSS growth<br />141.7 → 217.8 MiB</span></div>
+          <div class="stat"><strong>+0.8 MiB</strong><span>peak JS heap growth</span></div>
+        </div>
+        <p>The release gate also raster-compares every streamed page against buffered output. <a href="https://github.com/earonesty/boxpdf-html/pull/11" target="_blank" rel="noopener">See the implementation and benchmark record</a>.</p>
+      </article>
     </div>
   </section>
 
@@ -349,19 +381,21 @@ export default app;</code></pre>
 
   <section id="why" class="block">
     <h2>How it compares</h2>
-    <table class="compare">
-      <thead>
-        <tr><th></th><th>boxpdf</th><th>pdf-lib</th><th>@react-pdf/renderer</th><th>jsPDF</th></tr>
-      </thead>
-      <tbody>
-        <tr><th>Declarative layout</th><td>✓</td><td>✗</td><td>✓ (JSX)</td><td>✗</td></tr>
-        <tr><th>Cloudflare Workers</th><td>✓</td><td>✓</td><td>✗ (fontkit WASM)</td><td>partial</td></tr>
-        <tr><th>Streaming output</th><td>✓ <code>streamFlow</code> (Web Writable, bounded memory)</td><td>✗</td><td>Node only</td><td>✗</td></tr>
-        <tr><th>Custom fonts</th><td>✓ via fontkit (lazy)</td><td>✓ via fontkit</td><td>✓</td><td>limited</td></tr>
-        <tr><th>Core bundle</th><td>~7 KB gz</td><td>~250 KB gz</td><td>~250 KB gz</td><td>~80 KB gz</td></tr>
-        <tr><th>JSX runtime conflict</th><td>none</td><td>n/a</td><td>requires React</td><td>n/a</td></tr>
-      </tbody>
-    </table>
+    <div class="table-scroll" tabindex="0" aria-label="Library comparison">
+      <table class="compare">
+        <thead>
+          <tr><th></th><th>boxpdf</th><th>pdf-lib</th><th>@react-pdf/renderer</th><th>jsPDF</th></tr>
+        </thead>
+        <tbody>
+          <tr><th>Declarative layout</th><td>✓</td><td>✗</td><td>✓ (JSX)</td><td>✗</td></tr>
+          <tr><th>Cloudflare Workers</th><td>✓</td><td>✓</td><td>✗ (fontkit WASM)</td><td>partial</td></tr>
+          <tr><th>Streaming output</th><td>✓ <code>streamFlow</code> (Web Writable, bounded memory)</td><td>✗</td><td>Node only</td><td>✗</td></tr>
+          <tr><th>Custom fonts</th><td>✓ via fontkit (lazy)</td><td>✓ via fontkit</td><td>✓</td><td>limited</td></tr>
+          <tr><th>Core bundle</th><td>~7 KB gz</td><td>~250 KB gz</td><td>~250 KB gz</td><td>~80 KB gz</td></tr>
+          <tr><th>JSX runtime conflict</th><td>none</td><td>n/a</td><td>requires React</td><td>n/a</td></tr>
+        </tbody>
+      </table>
+    </div>
     <p class="footnote">Sizes are approximate. Measure yourself.</p>
   </section>
 
@@ -369,18 +403,47 @@ export default app;</code></pre>
     <h2>Memory bench</h2>
     <p class="block-lede">Peak heap during render. 50 lines of text per page. Each measurement runs in its own subprocess. <code>@react-pdf/renderer</code> uses Standard Helvetica (no font embedding) to match the boxpdf paths.</p>
     <p><img src="./design/peak-heap.svg" alt="Peak heap during render across page counts for streamFlow, renderFlow, and @react-pdf/renderer" style="max-width: 100%; height: auto;" /></p>
-    <table class="compare">
-      <thead>
-        <tr><th>Pages</th><th>streamFlow</th><th>renderFlow</th><th>@react-pdf/renderer</th><th>Output</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>50</td><td>12.8 MB</td><td>31.7 MB</td><td>160.8 MB</td><td>70 KB</td></tr>
-        <tr><td>250</td><td>15.4 MB</td><td>91.1 MB</td><td>643.1 MB</td><td>347 KB</td></tr>
-        <tr><td>500</td><td>18.7 MB</td><td>120.8 MB</td><td>1,219.9 MB</td><td>693 KB</td></tr>
-        <tr><td>1000</td><td>25.4 MB</td><td>219.6 MB</td><td>2,292.6 MB</td><td>1.4 MB</td></tr>
-      </tbody>
-    </table>
+    <div class="table-scroll" tabindex="0" aria-label="Memory benchmark results">
+      <table class="compare">
+        <thead>
+          <tr><th>Pages</th><th>streamFlow</th><th>renderFlow</th><th>@react-pdf/renderer</th><th>Output</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>50</td><td>12.8 MB</td><td>31.7 MB</td><td>160.8 MB</td><td>70 KB</td></tr>
+          <tr><td>250</td><td>15.4 MB</td><td>91.1 MB</td><td>643.1 MB</td><td>347 KB</td></tr>
+          <tr><td>500</td><td>18.7 MB</td><td>120.8 MB</td><td>1,219.9 MB</td><td>693 KB</td></tr>
+          <tr><td>1000</td><td>25.4 MB</td><td>219.6 MB</td><td>2,292.6 MB</td><td>1.4 MB</td></tr>
+        </tbody>
+      </table>
+    </div>
     <p class="footnote">Bench source: <a href="https://github.com/earonesty/boxpdf/blob/main/scripts/bench-memory.ts" target="_blank" rel="noopener">scripts/bench-memory.ts</a>. Design doc: <a href="https://github.com/earonesty/boxpdf/blob/main/docs/design/streaming.md" target="_blank" rel="noopener">docs/design/streaming.md</a>.</p>
+  </section>
+
+  <section id="security" class="block spotlight">
+    <p class="eyebrow">Encryption built into the writer</p>
+    <h2>Protect buffered and streamed PDFs</h2>
+    <p class="block-lede">
+      boxpdf writes PDF 2.0 Standard Security Handler documents with AES-256. Strings, content streams, fonts, and images are encrypted as objects are serialized, preserving bounded document memory.
+    </p>
+    <div class="showcase-grid">
+      <article class="showcase-card">
+        <h3>Library API</h3>
+        <pre><code>await streamFlow(pdf, writable, rows(), &#123;
+  encryption: &#123;
+    password: process.env.PDF_PASSWORD,
+    permissions: &#123; copying: false &#125;
+  &#125;
+&#125;);</code></pre>
+        <p>The same <code>encryption</code> option works with <code>savePdf</code>, <code>flowToPdf</code>, and <code>renderToPdf</code>.</p>
+      </article>
+      <article class="showcase-card">
+        <h3>CLI, without secrets in process arguments</h3>
+        <pre><code>export BOXPDF_PASSWORD="open me"
+npx boxpdf-html archive.html archive.pdf --stream --password-env BOXPDF_PASSWORD</code></pre>
+        <p>The CLI reads the password from the named environment variable. Owner passwords and viewer permissions are available through the library API. Viewer permissions are advisory, as defined by the PDF standard.</p>
+      </article>
+    </div>
+    <p class="footnote">Security design and scope: <a href="https://github.com/earonesty/boxpdf/blob/main/docs/design/encryption.md" target="_blank" rel="noopener">docs/design/encryption.md</a>.</p>
   </section>
 
   <section id="roadmap" class="block">
@@ -402,7 +465,8 @@ export default app;</code></pre>
       <li class="done">✓ CSS-like absolute positioning with paired-edge stretch and <code>zIndex</code></li>
       <li class="done">✓ Optional renderFlow profiling hooks for diagnosing layout measurement costs</li>
       <li class="done">✓ Verified end-to-end on Cloudflare Workers (core and Inter path)</li>
-      <li class="done">✓ Streaming page-at-a-time output via <code>streamFlow</code>. Peak heap stays flat at any page count.</li>
+      <li class="done">✓ Streaming page-at-a-time output via <code>streamFlow</code>, with bounded-document-memory release gates.</li>
+      <li class="done">✓ PDF 2.0 AES-256 password encryption for buffered and streamed output.</li>
     </ul>
   </section>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -216,6 +216,72 @@ pre code { color: inherit; }
   font-size: 14.5px;
 }
 
+/* Release spotlights */
+.spotlight {
+  position: relative;
+}
+.spotlight::before {
+  content: "";
+  position: absolute;
+  inset: 38px -24px -4px;
+  z-index: -1;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(145deg, #f8fafc, #f1f5f9);
+}
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+.showcase-card {
+  min-width: 0;
+  padding: 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow-sm);
+}
+.showcase-card h3 {
+  margin-top: 0;
+}
+.showcase-card pre {
+  margin: 14px 0;
+  padding: 16px 18px;
+  box-shadow: none;
+}
+.showcase-card p {
+  margin: 14px 0 0;
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 14px 0 18px;
+}
+.stat {
+  padding: 14px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+.stat strong,
+.stat span {
+  display: block;
+}
+.stat strong {
+  color: var(--accent);
+  font-size: 19px;
+  line-height: 1.2;
+}
+.stat span {
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
 /* Theme grid */
 .theme-grid {
   display: grid;
@@ -327,6 +393,18 @@ pre code { color: inherit; }
   color: var(--ink-soft);
 }
 .compare td:nth-child(2) { color: var(--accent); font-weight: 600; }
+.table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+}
+.table-scroll .compare {
+  min-width: 680px;
+}
+.table-scroll:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
 .footnote {
   color: var(--muted);
   font-size: 13.5px;
@@ -358,8 +436,33 @@ pre code { color: inherit; }
 }
 
 @media (max-width: 720px) {
-  .site nav { gap: 12px; }
+  .site {
+    gap: 18px;
+    padding-inline: 16px;
+  }
+  .site nav {
+    min-width: 0;
+    gap: 16px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .site nav::-webkit-scrollbar { display: none; }
   .site nav a { font-size: 13px; }
+  .site nav a { flex: 0 0 auto; }
+  main { padding-inline: 18px; }
   .hero { padding: 48px 0 32px; }
-  .tailwind-example { grid-template-columns: 1fr; }
+  .tailwind-example,
+  .showcase-grid { grid-template-columns: 1fr; }
+  .spotlight::before { inset-inline: -10px; }
+}
+
+@media (max-width: 420px) {
+  .stat-grid { grid-template-columns: 1fr; }
+  .stat {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    align-items: center;
+    gap: 8px;
+  }
+  .stat span { margin-top: 0; }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "typecheck": "tsc --noEmit",
     "visual:check:stream": "tsx scripts/check-stream-visuals.ts",
     "memory:check:continuation": "tsx scripts/check-continuation-memory.ts",
+    "docs:check": "node scripts/check-docs-site.mjs",
     "example": "tsx examples/index.ts",
     "gallery": "tsx scripts/build-gallery.ts",
     "prepublishOnly": "pnpm run typecheck && pnpm run test && pnpm run build"

--- a/scripts/check-docs-site.mjs
+++ b/scripts/check-docs-site.mjs
@@ -1,0 +1,53 @@
+import { access, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../docs");
+const html = await readFile(join(root, "index.html"), "utf8");
+const failures = [];
+
+const ids = [...html.matchAll(/\sid="([^"]+)"/g)].map((match) => match[1]);
+const knownIds = new Set();
+for (const id of ids) {
+  if (knownIds.has(id)) failures.push(`duplicate id: #${id}`);
+  knownIds.add(id);
+}
+
+for (const match of html.matchAll(/\s(?:href|src)="([^"]+)"/g)) {
+  const reference = match[1];
+  if (reference.startsWith("#")) {
+    if (!knownIds.has(reference.slice(1))) {
+      failures.push(`missing page anchor: ${reference}`);
+    }
+    continue;
+  }
+
+  if (/^(?:[a-z]+:|\/\/)/i.test(reference)) continue;
+  const pathname = decodeURIComponent(reference.split(/[?#]/, 1)[0]);
+  const target = join(root, pathname.endsWith("/") ? `${pathname}index.html` : pathname);
+  try {
+    await access(target);
+  } catch {
+    failures.push(`missing local asset: ${reference}`);
+  }
+}
+
+for (const match of html.matchAll(/<img\b([^>]*)>/g)) {
+  if (!/\salt="[^"]*"/.test(match[1])) {
+    failures.push(`image is missing alt text: ${match[0]}`);
+  }
+}
+
+for (const match of html.matchAll(/<a\b([^>]*)target="_blank"([^>]*)>/g)) {
+  const attributes = `${match[1]} ${match[2]}`;
+  if (!/\srel="[^"]*\bnoopener\b[^"]*"/.test(attributes)) {
+    failures.push(`target="_blank" link is missing rel="noopener": ${match[0]}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exitCode = 1;
+} else {
+  console.log(`docs site OK: ${knownIds.size} anchors and all local assets resolved`);
+}


### PR DESCRIPTION
## Summary

- replace the legacy Pages build with an explicit least-privilege deployment workflow using the current Node 24 action lines and `persist-credentials: false`
- showcase the released bounded-memory HTML streaming path and its one-wrapper 10→100 MiB benchmark
- showcase PDF 2.0 AES-256 encryption for buffered, streamed, and CLI output
- replace the overbroad “flat at any page count” claim with measured results
- make the navigation and comparison tables usable on narrow screens
- add a deterministic docs-site contract check to CI

## Validation

- `pnpm run docs:check`
- `pnpm run typecheck`
- `pnpm run test` — 205 tests
- `pnpm run build`
- `pnpm run visual:check:stream` — all 23 pages match buffered output
- `pnpm run memory:check:continuation` — 81→810 pages; retained heap 16.2→25.8 MiB
- Chromium visual inspection at 1440×1000 and 390×844
- no browser console warnings/errors; no mobile document overflow

## Pages migration note

The repository currently uses the legacy `main/docs` Pages builder. After this PR is merged, switch **Settings → Pages → Build and deployment → Source** to **GitHub Actions** so `.github/workflows/pages.yml` owns deployments. The setting is intentionally not changed while this PR is unmerged, so the current public page remains available.